### PR TITLE
feat: Adding falco helm charts and configuration

### DIFF
--- a/cluster/flux-system/helm-chart-repositories/falcosecurity-charts.yaml
+++ b/cluster/flux-system/helm-chart-repositories/falcosecurity-charts.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: falcosecurity-charts
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://falcosecurity.github.io/charts
+  timeout: 3m

--- a/cluster/kube-system/kured/kured.yaml
+++ b/cluster/kube-system/kured/kured.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: kured
-      version: 2.2.0
+      version: '>=2.2.0 <3.0.0'
       sourceRef:
         kind: HelmRepository
         name: weaveworks-kured-charts

--- a/cluster/kube-system/metrics-server/metrics-server.yaml
+++ b/cluster/kube-system/metrics-server/metrics-server.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: metrics-server
-      version: 2.11.1
+      version: '>=2.11.1 <3.0.0'
       sourceRef:
         kind: HelmRepository
         name: kubernetes-stable-charts

--- a/cluster/network/external-dns/external-dns.yaml
+++ b/cluster/network/external-dns/external-dns.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: external-dns
-      version: 3.5.1
+      version: '>=3.5.1 <4.0.0'
       sourceRef:
         kind: HelmRepository
         name: bitnami-charts

--- a/cluster/network/oauth2-proxy/oauth2-proxy.yaml
+++ b/cluster/network/oauth2-proxy/oauth2-proxy.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: oauth2-proxy
-      version: 3.2.3
+      version: '>=3.2.3 <3.3.0'
       sourceRef:
         kind: HelmRepository
         name: kubernetes-stable-charts

--- a/cluster/security/falco-exporter/falco-exporter.yaml
+++ b/cluster/security/falco-exporter/falco-exporter.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: falco-exporter
+  namespace: security
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: falco-exporter
+      version: '>=0.3.8 <1.0.0'
+      sourceRef:
+        kind: HelmRepository
+        name: falcosecurity-charts
+        namespace: flux-system
+      interval: 10m
+  test:
+    enable: false # Enable helm test
+  install:
+    remediation: # perform remediation when helm install fails
+      retries: 3
+  upgrade:
+    remediation: # perform remediation when helm upgrade fails
+      retries: 3
+      remediateLastFailure: true # remediate the last failure, when no retries remain
+    cleanupOnFail: true
+  rollback:
+    timeout: 10m
+    recreate: true
+    cleanupOnFail: true
+  values:
+    podSecurityPolicy:
+      create: true
+    grafanaDashboard:
+      enabled: false
+      namespace: default
+    serviceMonitor:
+      # Enable the deployment of a Service Monitor for the Prometheus Operator.
+      enabled: false
+      # Specify Additional labels to be added on the Service Monitor.
+      additionalLabels: {}
+      # Specify a user defined interval. When not specified Prometheus default interval is used.
+      interval: ''
+      # Specify a user defined scrape timeout. When not specified Prometheus default scrape timeout is used.
+      scrapeTimeout: ''
+    scc:
+      # true here enabled creation of Security Context Constraints in Openshift
+      create: false

--- a/cluster/security/falco/falco.yaml
+++ b/cluster/security/falco/falco.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: falco
+  namespace: security
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: falco
+      version: '>=1.5.3 <2.0.0'
+      sourceRef:
+        kind: HelmRepository
+        name: falcosecurity-charts
+        namespace: flux-system
+      interval: 10m
+  test:
+    enable: false # Enable helm test
+  install:
+    remediation: # perform remediation when helm install fails
+      retries: 3
+  upgrade:
+    remediation: # perform remediation when helm upgrade fails
+      retries: 3
+      remediateLastFailure: true # remediate the last failure, when no retries remain
+    cleanupOnFail: true
+  rollback:
+    timeout: 10m
+    recreate: true
+    cleanupOnFail: true
+  values:
+    docker:
+      enabled: true
+      socket: /var/run/docker.sock
+    containerd:
+      enabled: false
+      socket: /run/containerd/containerd.sock
+    podSecurityPolicy:
+      create: true
+    ebpf:
+      # Enable eBPF support for Falco
+      enabled: false
+      settings:
+        # Needed to enable eBPF JIT at runtime for performance reasons.
+        # Can be skipped if eBPF JIT is enabled from outside the container
+        hostNetwork: true
+    auditLog:
+      # true here activates the K8s Audit Log feature for Falco
+      enabled: false
+      dynamicBackend:
+        # true here configures an AuditSink who will receive the K8s audit logs
+        enabled: false
+        # define if auditsink client config should point to a fixed url, not the
+        # default webserver service
+        url: ''


### PR DESCRIPTION
Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>

# Description

Adding falco security into the stack with the exporter configured. This requires a `ServiceMonitor` resource to still be created for the Prometheus operator.

This PR is pending `arm64` image support which has recently been actioned. https://github.com/falcosecurity/falco/issues/1445

## Checklist

- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://developercertificate.org/)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] All pre-commit hook validation passed successfully.
- [x] All commits contain a well-written commit description including a title, description, and a Fixes: #XXX line if the commit addresses a particular GitHub issue.
- [x] All workflow validation and compliance checks are passing.

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #

## Notes

Add special notes for your reviewer here.
