### PR TITLE
feat(kguardian): update to PR-670 security/stability/UI fixes

### DIFF
--- a/kubernetes/apps/base/kguardian/kguardian/app/ocirepository.yaml
+++ b/kubernetes/apps/base/kguardian/kguardian/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.8.2
+    tag: 1.8.2-pr670
   url: oci://ghcr.io/kguardian-dev/charts/kguardian

--- a/kubernetes/apps/base/kguardian/kguardian/app/values.yaml
+++ b/kubernetes/apps/base/kguardian/kguardian/app/values.yaml
@@ -7,7 +7,7 @@ controller:
 
 broker:
   image:
-    tag: "v1.6.1"
+    tag: "pr-670"
 
 frontend:
   image:


### PR DESCRIPTION
## Summary
- Updates kguardian OCI chart tag to `1.8.2-pr670` which includes Helm template security hardening (DB secret, SA tokens, read-only mounts, init container security contexts)
- Updates broker image to `pr-670` with stability fixes (`.expect()` → `?` error propagation, transaction wrapping for syscall batch inserts)
- Frontend, LLM Bridge, and MCP Server already on `pr-670`

## Changes
- `ocirepository.yaml`: chart tag `1.8.2` → `1.8.2-pr670`
- `values.yaml`: broker image tag `v1.6.1` → `pr-670`

## Test plan
- [ ] Verify Flux reconciles the new chart version
- [ ] Confirm broker pod starts and connects to database
- [ ] Confirm frontend loads with kguardian namespace visible
- [ ] Verify light mode readability improvements in AI assistant