### PR TITLE
chore: upgrade recyclarr to v8

### DIFF
--- a/kubernetes/apps/base/home-system/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/base/home-system/recyclarr/app/helmrelease.yaml
@@ -50,7 +50,9 @@ spec:
           app:
             image:
               repository: ghcr.io/recyclarr/recyclarr
-              tag: 7.5.2@sha256:2550848d43a453f2c6adf3582f2198ac719f76670691d76de0819053103ef2fb
+              tag: 8.0.1@sha256:d9dcb82a2a23cb07b9c0caf7e4f8cb15b558390d953d591f5d35a68e12ff6bd7
+            env:
+              RECYCLARR_DATA_DIR: /tmp
             envFrom:
               - secretRef:
                   name: recyclarr-secret

--- a/kubernetes/apps/base/home-system/recyclarr/app/resources/recyclarr.yml
+++ b/kubernetes/apps/base/home-system/recyclarr/app/resources/recyclarr.yml
@@ -1,17 +1,18 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/recyclarr/recyclarr/master/schemas/config-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/recyclarr/recyclarr/refs/tags/v8.0.0/schemas/config-schema.json
 sonarr:
-  sonarr:
+  series:
     base_url: http://sonarr.home-system.svc.cluster.local
     api_key: !env_var SONARR_API_KEY
     delete_old_custom_formats: true
-    replace_existing_custom_formats: true
-    include:
-      - template: sonarr-quality-definition-series
-      - template: sonarr-v4-quality-profile-web-1080p
-      - template: sonarr-v4-custom-formats-web-1080p
+    media_management:
+      propers_and_repacks: do_not_prefer
+    quality_definition:
+      type: series
     quality_profiles:
-      - name: WEB-1080p
+      - trash_id: 72dae194fc92bf828f32cde7744e51a1 # WEB-1080p
+        reset_unmatched_scores:
+          enabled: true
     custom_formats:
       - trash_ids:
           - 32b367365729d530ca1c124a0b180c64 # Bad Dual Groups
@@ -23,29 +24,24 @@ sonarr:
           - name: WEB-1080p
 
 radarr:
-  radarr:
+  movies:
     base_url: http://radarr.home-system.svc.cluster.local
     api_key: !env_var RADARR_API_KEY
     delete_old_custom_formats: true
-    replace_existing_custom_formats: true
+    media_management:
+      propers_and_repacks: do_not_prefer
+    quality_definition:
+      type: movie
     quality_profiles:
-      - name: SQP-1 (2160p)
-    include:
-      - template: radarr-quality-definition-sqp-streaming
-      - template: radarr-quality-profile-sqp-1-2160p-default
-      - template: radarr-custom-formats-sqp-1-2160p
+      - trash_id: d1d67249d3890e49bc12e275d989a7e9 # HD Bluray + WEB
+        reset_unmatched_scores:
+          enabled: true
     custom_formats:
       - trash_ids:
-          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
-        assign_scores_to:
-          - name: SQP-1 (2160p)
-            score: 0
-      - trash_ids:
           - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-          - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
           - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
           - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
           - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
           - f537cf427b64c38c8e36298f657e4828 # Scene
         assign_scores_to:
-          - name: SQP-1 (2160p)
+          - name: HD Bluray + WEB


### PR DESCRIPTION
## Summary
- Upgrade recyclarr from 7.5.2 to 8.0.1 ([similar to onedr0p/home-ops#10537](https://github.com/onedr0p/home-ops/pull/10537))
- Migrate config to v8 format: `sonarr:` → `series:`, `radarr:` → `movies:`, guide-backed quality profiles via `trash_id`
- Switch radarr from SQP-1 (2160p) to **HD Bluray + WEB** (1080p) - dropping all 4K/2160p configurations
- Keep sonarr on **WEB-1080p** profile
- Add `RECYCLARR_DATA_DIR: /tmp` env var (v8 requirement)
- Replace deprecated `replace_existing_custom_formats` with `media_management.propers_and_repacks`

## Changes
- `helmrelease.yaml`: Image tag bump + new env var
- `recyclarr.yml`: Full v8 config migration
