### PR TITLE
fix: add missing hard dependencies to Flux Kustomizations

### DIFF
--- a/kubernetes/apps/base/actions-runner-system/gha-runner-scale-set/ks.yaml
+++ b/kubernetes/apps/base/actions-runner-system/gha-runner-scale-set/ks.yaml
@@ -11,6 +11,11 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 3m
+  dependsOn:
+    - name: gha-runner-scale-set-controller
+      namespace: actions-runner-system
+    - name: onepassword
+      namespace: external-secrets
   path: "./apps/base/actions-runner-system/gha-runner-scale-set/app"
   prune: true
   wait: true

--- a/kubernetes/apps/base/game-servers/enemy-territory/ks.yaml
+++ b/kubernetes/apps/base/game-servers/enemy-territory/ks.yaml
@@ -13,6 +13,11 @@ spec:
   path: "./apps/base/game-servers/enemy-territory/app"
   prune: true
   wait: true
+  dependsOn:
+    - name: democratic-csi
+      namespace: democratic-csi
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
   sourceRef:
     kind: OCIRepository
     name: flux-system

--- a/kubernetes/apps/base/game-servers/minecraft-bedrock-broadcaster/ks.yaml
+++ b/kubernetes/apps/base/game-servers/minecraft-bedrock-broadcaster/ks.yaml
@@ -9,6 +9,12 @@ spec:
   decryption:
     provider: sops
   dependsOn:
+    - name: democratic-csi
+      namespace: democratic-csi
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   interval: 30m

--- a/kubernetes/apps/base/game-servers/minecraft-bedrock/ks.yaml
+++ b/kubernetes/apps/base/game-servers/minecraft-bedrock/ks.yaml
@@ -9,6 +9,12 @@ spec:
   decryption:
     provider: sops
   dependsOn:
+    - name: democratic-csi
+      namespace: democratic-csi
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   interval: 30m

--- a/kubernetes/apps/base/game-servers/minecraft-ketting/ks.yaml
+++ b/kubernetes/apps/base/game-servers/minecraft-ketting/ks.yaml
@@ -9,6 +9,12 @@ spec:
   decryption:
     provider: sops
   dependsOn:
+    - name: democratic-csi
+      namespace: democratic-csi
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   interval: 30m

--- a/kubernetes/apps/base/game-servers/minecraft/ks.yaml
+++ b/kubernetes/apps/base/game-servers/minecraft/ks.yaml
@@ -9,6 +9,12 @@ spec:
   decryption:
     provider: sops
   dependsOn:
+    - name: democratic-csi
+      namespace: democratic-csi
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   interval: 30m

--- a/kubernetes/apps/base/home-system/autobrr/ks.yaml
+++ b/kubernetes/apps/base/home-system/autobrr/ks.yaml
@@ -21,6 +21,10 @@ spec:
   dependsOn:
     - name: democratic-csi
       namespace: democratic-csi
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   targetNamespace: home-system

--- a/kubernetes/apps/base/home-system/home-assistant/ks.yaml
+++ b/kubernetes/apps/base/home-system/home-assistant/ks.yaml
@@ -21,6 +21,10 @@ spec:
   dependsOn:
     - name: democratic-csi
       namespace: democratic-csi
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   targetNamespace: home-system

--- a/kubernetes/apps/base/home-system/jellyseerr/ks.yaml
+++ b/kubernetes/apps/base/home-system/jellyseerr/ks.yaml
@@ -21,6 +21,10 @@ spec:
   dependsOn:
     - name: democratic-csi
       namespace: democratic-csi
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   targetNamespace: home-system

--- a/kubernetes/apps/base/home-system/mosquitto/ks.yaml
+++ b/kubernetes/apps/base/home-system/mosquitto/ks.yaml
@@ -19,6 +19,12 @@ spec:
     name: flux-system
     namespace: flux-system
   dependsOn:
+    - name: democratic-csi
+      namespace: democratic-csi
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   targetNamespace: home-system

--- a/kubernetes/apps/base/home-system/prowlarr/ks.yaml
+++ b/kubernetes/apps/base/home-system/prowlarr/ks.yaml
@@ -21,6 +21,10 @@ spec:
   dependsOn:
     - name: democratic-csi
       namespace: democratic-csi
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   targetNamespace: home-system

--- a/kubernetes/apps/base/home-system/qbittorrent/ks.yaml
+++ b/kubernetes/apps/base/home-system/qbittorrent/ks.yaml
@@ -21,6 +21,10 @@ spec:
   dependsOn:
     - name: democratic-csi
       namespace: democratic-csi
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   targetNamespace: home-system

--- a/kubernetes/apps/base/home-system/qui/ks.yaml
+++ b/kubernetes/apps/base/home-system/qui/ks.yaml
@@ -19,6 +19,8 @@ spec:
     name: flux-system
     namespace: flux-system
   dependsOn:
+    - name: onepassword
+      namespace: external-secrets
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: volsync

--- a/kubernetes/apps/base/home-system/radarr/ks.yaml
+++ b/kubernetes/apps/base/home-system/radarr/ks.yaml
@@ -21,6 +21,10 @@ spec:
   dependsOn:
     - name: democratic-csi
       namespace: democratic-csi
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   targetNamespace: home-system

--- a/kubernetes/apps/base/home-system/recyclarr/ks.yaml
+++ b/kubernetes/apps/base/home-system/recyclarr/ks.yaml
@@ -21,6 +21,10 @@ spec:
   dependsOn:
     - name: democratic-csi
       namespace: democratic-csi
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   targetNamespace: home-system

--- a/kubernetes/apps/base/home-system/sabnzbd/ks.yaml
+++ b/kubernetes/apps/base/home-system/sabnzbd/ks.yaml
@@ -21,6 +21,10 @@ spec:
   dependsOn:
     - name: democratic-csi
       namespace: democratic-csi
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   targetNamespace: home-system

--- a/kubernetes/apps/base/home-system/sonarr/ks.yaml
+++ b/kubernetes/apps/base/home-system/sonarr/ks.yaml
@@ -21,6 +21,10 @@ spec:
   dependsOn:
     - name: democratic-csi
       namespace: democratic-csi
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   targetNamespace: home-system

--- a/kubernetes/apps/base/home-system/tautulli/ks.yaml
+++ b/kubernetes/apps/base/home-system/tautulli/ks.yaml
@@ -21,6 +21,10 @@ spec:
   dependsOn:
     - name: democratic-csi
       namespace: democratic-csi
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   targetNamespace: home-system

--- a/kubernetes/apps/base/home-system/zigbee2mqtt/ks.yaml
+++ b/kubernetes/apps/base/home-system/zigbee2mqtt/ks.yaml
@@ -23,6 +23,10 @@ spec:
       namespace: democratic-csi
     - name: mosquitto
       namespace: home-system
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   targetNamespace: home-system

--- a/kubernetes/apps/base/network-system/cert-manager/ks.yaml
+++ b/kubernetes/apps/base/network-system/cert-manager/ks.yaml
@@ -19,6 +19,9 @@ spec:
       kind: ClusterIssuer
       failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+  dependsOn:
+    - name: onepassword
+      namespace: external-secrets
   interval: 30m
   retryInterval: 1m
   timeout: 3m

--- a/kubernetes/apps/base/network-system/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/base/network-system/cloudflare-tunnel/ks.yaml
@@ -21,4 +21,6 @@ spec:
   dependsOn:
     - name: external-dns
       namespace: network-system
+    - name: onepassword
+      namespace: external-secrets
   targetNamespace: network-system

--- a/kubernetes/apps/base/network-system/external-dns-unifi/ks.yaml
+++ b/kubernetes/apps/base/network-system/external-dns-unifi/ks.yaml
@@ -9,6 +9,8 @@ spec:
   dependsOn:
     - name: external-dns
       namespace: network-system
+    - name: onepassword
+      namespace: external-secrets
   decryption:
     provider: sops
   interval: 30m

--- a/kubernetes/apps/base/network-system/external-dns/ks.yaml
+++ b/kubernetes/apps/base/network-system/external-dns/ks.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   decryption:
     provider: sops
+  dependsOn:
+    - name: onepassword
+      namespace: external-secrets
   interval: 30m
   retryInterval: 1m
   timeout: 3m

--- a/kubernetes/apps/base/network-system/oauth2-proxy/ks.yaml
+++ b/kubernetes/apps/base/network-system/oauth2-proxy/ks.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   decryption:
     provider: sops
+  dependsOn:
+    - name: onepassword
+      namespace: external-secrets
   interval: 30m
   retryInterval: 1m
   timeout: 3m

--- a/kubernetes/apps/base/observability/grafana/ks.yaml
+++ b/kubernetes/apps/base/observability/grafana/ks.yaml
@@ -42,6 +42,10 @@ spec:
   dependsOn:
     - name: grafana
       namespace: observability
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   targetNamespace: observability

--- a/kubernetes/apps/base/observability/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/ks.yaml
@@ -19,6 +19,10 @@ spec:
     name: flux-system
     namespace: flux-system
   dependsOn:
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
     - name: volsync
       namespace: volsync-system
   targetNamespace: observability


### PR DESCRIPTION
## Summary

- Add `onepassword` (external-secrets ns) dependency to 25 apps that use `ExternalSecret` CRDs referencing the `ClusterSecretStore` — without this, fresh cluster bootstrap races and secrets fail to resolve
- Add `rook-ceph-cluster` (rook-ceph ns) dependency to 20 apps using `ceph-block` StorageClass PVCs
- Add `democratic-csi` dependency to game-servers (minecraft variants) and `mosquitto` that use `truenas-iscsi-csi` PVCs but were missing the storage provider dependency
- Add `gha-runner-scale-set-controller` dependency to `gha-runner-scale-set` so the controller is ready before runners attempt to register
- `enemy-territory` had **zero** `dependsOn` despite using both storage providers — now correctly declares both

Soft CRD dependencies (GrafanaDashboard, ServiceMonitor, HTTPRoute, PrometheusRule) are intentionally omitted per FluxCD best practices — Flux retries automatically and these don't block app startup.

## Test plan

- [ ] Verify `pre-commit run --all-files` passes (confirmed locally)
- [ ] Review dependency graph doesn't introduce circular dependencies
- [ ] Confirm `onepassword` → `external-secrets` chain is correct (onepassword already depends on external-secrets)
- [ ] Validate no existing `dependsOn` entries were removed, only additions
- [ ] Consider testing on fresh cluster bootstrap to verify ordering