### PR TITLE
feat(home-system): add bazarr for subtitle management

### DIFF
--- a/kubernetes/apps/base/home-system/bazarr/app/externalsecret.yaml
+++ b/kubernetes/apps/base/home-system/bazarr/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: bazarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: bazarr-secret
+    template:
+      data:
+        BAZARR__AUTH__APIKEY: "{{ .BAZARR_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: bazarr

--- a/kubernetes/apps/base/home-system/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/base/home-system/bazarr/app/helmrelease.yaml
@@ -1,0 +1,110 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bazarr
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  install:
+    timeout: 10m
+    replace: true
+    crds: CreateReplace
+    createNamespace: true
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  upgrade:
+    remediation:
+      remediateLastFailure: true
+      retries: 3
+      strategy: rollback
+    cleanupOnFail: true
+    crds: CreateReplace
+  test:
+    enable: true
+  rollback:
+    recreate: true
+    force: true
+    cleanupOnFail: true
+  uninstall:
+    keepHistory: false
+  driftDetection:
+    mode: enabled
+  maxHistory: 3
+  values:
+    controllers:
+      bazarr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/bazarr
+              tag: 1.5.5@sha256:0949a30fb6e6703a63aaa9775760b8af820f7871f6a9aa9207e2ea00fd855e2c
+            env:
+              TZ: Australia/Melbourne
+            envFrom:
+              - secretRef:
+                  name: bazarr-secret
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/system/ping
+                    port: &port 6767
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: bazarr
+        ports:
+          http:
+            port: *port
+    persistence:
+      config:
+        existingClaim: bazarr-ceph
+      tmp:
+        type: emptyDir
+      media:
+        type: nfs
+        server: expanse.internal
+        path: /mnt/tank/media
+        globalMounts:
+          - path: /media

--- a/kubernetes/apps/base/home-system/bazarr/app/httproute.yaml
+++ b/kubernetes/apps/base/home-system/bazarr/app/httproute.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: bazarr
+  namespace: home-system
+spec:
+  parentRefs:
+    - name: envoy-external
+      namespace: network-system
+      sectionName: https
+    - name: envoy-internal
+      namespace: network-system
+      sectionName: https
+  hostnames:
+    - 'bazarr.${CLUSTER_DOMAIN}'
+  rules:
+    - backendRefs:
+        - name: bazarr
+          port: 6767
+          weight: 100

--- a/kubernetes/apps/base/home-system/bazarr/app/kustomization.yaml
+++ b/kubernetes/apps/base/home-system/bazarr/app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - externalsecret.yaml
+  - helmrelease.yaml
+  - httproute.yaml
+  - pvc-ceph.yaml
+  - replicationsource.yaml
+  - volsync-externalsecret.yaml

--- a/kubernetes/apps/base/home-system/bazarr/app/pvc-ceph.yaml
+++ b/kubernetes/apps/base/home-system/bazarr/app/pvc-ceph.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bazarr-ceph
+  namespace: home-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/base/home-system/bazarr/app/replicationsource.yaml
+++ b/kubernetes/apps/base/home-system/bazarr/app/replicationsource.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: bazarr
+spec:
+  sourcePVC: bazarr-ceph
+  trigger:
+    schedule: "0 * * * *"
+  kopia:
+    accessModes:
+      - ReadWriteOnce
+    cacheAccessModes:
+      - ReadWriteOnce
+    cacheCapacity: 5Gi
+    cacheStorageClassName: ceph-block
+    compression: zstd-fastest
+    copyMethod: Snapshot
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    parallelism: 2
+    repository: bazarr-volsync-secret
+    retain:
+      hourly: 24
+      daily: 7
+    storageClassName: ceph-block
+    volumeSnapshotClassName: csi-ceph-blockpool

--- a/kubernetes/apps/base/home-system/bazarr/app/volsync-externalsecret.yaml
+++ b/kubernetes/apps/base/home-system/bazarr/app/volsync-externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: bazarr-volsync
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: bazarr-volsync-secret
+    template:
+      data:
+        KOPIA_FS_PATH: /repository
+        KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"
+        KOPIA_REPOSITORY: filesystem:///repository
+  dataFrom:
+    - extract:
+        key: volsync-template

--- a/kubernetes/apps/base/home-system/bazarr/ks.yaml
+++ b/kubernetes/apps/base/home-system/bazarr/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: bazarr
+  namespace: home-system
+spec:
+  decryption:
+    provider: sops
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m
+  path: "./apps/base/home-system/bazarr/app"
+  prune: true
+  wait: false
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+    namespace: flux-system
+  dependsOn:
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  targetNamespace: home-system

--- a/kubernetes/apps/overlays/cluster-00/kustomization.yaml
+++ b/kubernetes/apps/overlays/cluster-00/kustomization.yaml
@@ -42,6 +42,7 @@ resources:
   - ../../base/game-servers/minecraft-rcon-web/ks.yaml
   # - ../../base/game-servers/minecraft-router/ks.yaml
   - ../../base/home-system/autobrr/ks.yaml
+  - ../../base/home-system/bazarr/ks.yaml
   # - ../../base/home-system/emqx/ks.yaml
   - ../../base/home-system/home-assistant/ks.yaml
   - ../../base/home-system/jellyseerr/ks.yaml


### PR DESCRIPTION
## Summary

- Add bazarr as a companion to Sonarr/Radarr for automated subtitle downloads
- Uses `ghcr.io/home-operations/bazarr:1.5.5` container image
- Follows the same patterns as other home-system apps: ceph-block storage, VolSync/Kopia hourly backups, ExternalSecret from 1Password, HTTPRoute via envoy-gateway, NFS media mount