### PR TITLE
feat(home-system): add smtp-relay for cluster email delivery

### DIFF
--- a/kubernetes/apps/base/home-system/smtp-relay/app/externalsecret.yaml
+++ b/kubernetes/apps/base/home-system/smtp-relay/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: smtp-relay
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: smtp-relay-secret
+    template:
+      data:
+        SMTP_RELAY_HOSTNAME: "{{ .SMTP_RELAY_HOSTNAME }}"
+        SMTP_RELAY_PASSWORD: "{{ .SMTP_RELAY_PASSWORD }}"
+        SMTP_RELAY_SERVER: "{{ .SMTP_RELAY_SERVER }}"
+        SMTP_RELAY_USERNAME: "{{ .SMTP_RELAY_USERNAME }}"
+  dataFrom:
+    - extract:
+        key: smtp-relay

--- a/kubernetes/apps/base/home-system/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/base/home-system/smtp-relay/app/helmrelease.yaml
@@ -1,0 +1,119 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: smtp-relay
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  install:
+    timeout: 10m
+    replace: true
+    crds: CreateReplace
+    createNamespace: true
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  upgrade:
+    remediation:
+      remediateLastFailure: true
+      retries: 3
+      strategy: rollback
+    cleanupOnFail: true
+    crds: CreateReplace
+  test:
+    enable: true
+  rollback:
+    recreate: true
+    force: true
+    cleanupOnFail: true
+  uninstall:
+    keepHistory: false
+  driftDetection:
+    mode: enabled
+  maxHistory: 3
+  values:
+    controllers:
+      smtp-relay:
+        replicas: 2
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/foxcpp/maddy
+              tag: 0.8.2@sha256:eeb5813fc4d101ec5d8f7b08b7255fd76ced2a06884ea94450c8a9a22fd6a08d
+            env:
+              SMTP_RELAY_SMTP_PORT: &port 25
+            envFrom:
+              - secretRef:
+                  name: smtp-relay-secret
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 64Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: smtp-relay
+        ports:
+          smtp:
+            port: *port
+    configMaps:
+      config:
+        data:
+          maddy.conf: |-
+            state_dir /cache/state
+            runtime_dir /cache/run
+            tls off
+            hostname {env:SMTP_RELAY_HOSTNAME}
+            smtp tcp://0.0.0.0:{env:SMTP_RELAY_SMTP_PORT} {
+                default_source {
+                    deliver_to &remote_queue
+                }
+            }
+            target.queue remote_queue {
+                target &remote_smtp
+            }
+            target.smtp remote_smtp {
+                starttls yes
+                auth plain {env:SMTP_RELAY_USERNAME} {env:SMTP_RELAY_PASSWORD}
+                targets tcp://{env:SMTP_RELAY_SERVER}:587
+            }
+    persistence:
+      cache:
+        type: emptyDir
+      config-file:
+        type: configMap
+        identifier: config
+        globalMounts:
+          - path: /data/maddy.conf
+            subPath: maddy.conf

--- a/kubernetes/apps/base/home-system/smtp-relay/app/kustomization.yaml
+++ b/kubernetes/apps/base/home-system/smtp-relay/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - externalsecret.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/base/home-system/smtp-relay/ks.yaml
+++ b/kubernetes/apps/base/home-system/smtp-relay/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: smtp-relay
+  namespace: home-system
+spec:
+  decryption:
+    provider: sops
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m
+  path: "./apps/base/home-system/smtp-relay/app"
+  prune: true
+  wait: true
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+    namespace: flux-system
+  dependsOn:
+    - name: onepassword
+      namespace: external-secrets
+  targetNamespace: home-system

--- a/kubernetes/apps/overlays/cluster-00/kustomization.yaml
+++ b/kubernetes/apps/overlays/cluster-00/kustomization.yaml
@@ -53,6 +53,7 @@ resources:
   - ../../base/home-system/radarr/ks.yaml
   - ../../base/home-system/recyclarr/ks.yaml
   - ../../base/home-system/sabnzbd/ks.yaml
+  - ../../base/home-system/smtp-relay/ks.yaml
   - ../../base/home-system/sonarr/ks.yaml
   - ../../base/home-system/tautulli/ks.yaml
   # - ../../base/home-system/zigbee2mqtt/ks.yaml


### PR DESCRIPTION
## Summary

- Deploy [maddy](https://github.com/foxcpp/maddy) SMTP relay as a central mail gateway for cluster services
- Apps like Jellyseerr, Grafana, and Sonarr can send emails as `noreply@owncloud.ai` by pointing SMTP to `smtp-relay:25` — no per-app email credentials needed
- Runs 2 replicas with RollingUpdate strategy for availability
- Credentials pulled from 1Password via ExternalSecret

## App SMTP configuration

| Setting | Value |
|---------|-------|
| Host | `smtp-relay` |
| Port | `25` |
| Auth | None |
| TLS | Off |
| From | `noreply@owncloud.ai` |

## Prerequisites

- [x] Gmail App Password generated
- [x] Gmail "Send mail as" verified for `noreply@owncloud.ai`
- [x] Cloudflare Email Routing configured for `owncloud.ai`
- [x] 1Password `smtp-relay` item created with `SMTP_RELAY_HOSTNAME`, `SMTP_RELAY_SERVER`, `SMTP_RELAY_USERNAME`, `SMTP_RELAY_PASSWORD`

## Test plan

- [ ] Confirm smtp-relay pods start (2 replicas)
- [ ] Send a test email from Jellyseerr
- [ ] Verify email arrives as `noreply@owncloud.ai`