### PR TITLE
fix(kguardian): increase DB CPU request to 1 core and remove CPU limit

### DIFF
--- a/kubernetes/apps/base/kguardian/kguardian/app/values.yaml
+++ b/kubernetes/apps/base/kguardian/kguardian/app/values.yaml
@@ -26,6 +26,14 @@ llmBridge:
       enabled: true
       name: "kguardian-secrets"
 
+database:
+  resources:
+    limits:
+      memory: 512Mi
+    requests:
+      cpu: "1"
+      memory: 256Mi
+
 mcpServer:
   enabled: true
   useKmcp: true


### PR DESCRIPTION
## Summary

- Increase kguardian postgres DB CPU request from 100m to 1 core
- Remove CPU limit (was 500m) to allow bursting
- Resolves `CPUThrottlingHigh` alert — container was 99.96% throttled

## Test plan

- [ ] Verify kguardian-db pod restarts with new resource settings
- [ ] Confirm CPUThrottlingHigh alert clears