### PR TITLE
feat(observability): add Loki + Alloy for centralized log collection

### DIFF
--- a/kubernetes/apps/base/flux-system/repositories/helm/grafana-charts.yaml
+++ b/kubernetes/apps/base/flux-system/repositories/helm/grafana-charts.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: grafana-charts
+  namespace: flux-system
+spec:
+  interval: 2h
+  url: https://grafana.github.io/helm-charts

--- a/kubernetes/apps/base/flux-system/repositories/helm/kustomization.yaml
+++ b/kubernetes/apps/base/flux-system/repositories/helm/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - dex-chart.yaml
   - fairwinds-charts.yaml
   - gatekeeper-charts.yaml
+  - grafana-charts.yaml
   - ingress-nginx-chart.yaml
   - loft-charts.yaml
   - minecraft-server-charts.yaml

--- a/kubernetes/apps/base/observability/alloy/app/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/alloy/app/helmrelease.yaml
@@ -1,0 +1,111 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: alloy
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: alloy
+      version: 1.6.0
+      sourceRef:
+        kind: HelmRepository
+        name: grafana-charts
+        namespace: flux-system
+      interval: 10m
+  install:
+    timeout: 10m
+    replace: true
+    crds: CreateReplace
+    createNamespace: true
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  upgrade:
+    remediation:
+      remediateLastFailure: true
+      retries: 3
+      strategy: rollback
+    cleanupOnFail: true
+    crds: CreateReplace
+  test:
+    enable: true
+  rollback:
+    recreate: true
+    force: true
+    cleanupOnFail: true
+  uninstall:
+    keepHistory: false
+  driftDetection:
+    mode: enabled
+  maxHistory: 3
+  values:
+    alloy:
+      configMap:
+        content: |-
+          // Discover all pods in the cluster
+          discovery.kubernetes "pods" {
+            role = "pod"
+          }
+
+          // Relabel Kubernetes metadata into Loki labels
+          discovery.relabel "pods" {
+            targets = discovery.kubernetes.pods.targets
+
+            rule {
+              source_labels = ["__meta_kubernetes_namespace"]
+              target_label  = "namespace"
+            }
+
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "pod"
+            }
+
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_name"]
+              target_label  = "container"
+            }
+
+            rule {
+              source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+              target_label  = "app"
+            }
+
+            rule {
+              source_labels = ["__meta_kubernetes_pod_node_name"]
+              target_label  = "node"
+            }
+          }
+
+          // Collect logs via Kubernetes API
+          loki.source.kubernetes "pods" {
+            targets    = discovery.relabel.pods.output
+            forward_to = [loki.process.pod_logs.receiver]
+          }
+
+          // Add static cluster label
+          loki.process "pod_logs" {
+            stage.static_labels {
+              values = {
+                cluster = "cluster-00",
+              }
+            }
+            forward_to = [loki.write.default.receiver]
+          }
+
+          // Ship to Loki
+          loki.write "default" {
+            endpoint {
+              url = "http://loki-gateway.observability.svc.cluster.local/loki/api/v1/push"
+            }
+          }
+    controller:
+      type: deployment
+      replicas: 1
+    serviceAccount:
+      create: true
+    crds:
+      create: false

--- a/kubernetes/apps/base/observability/alloy/app/kustomization.yaml
+++ b/kubernetes/apps/base/observability/alloy/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/kubernetes/apps/base/observability/alloy/ks.yaml
+++ b/kubernetes/apps/base/observability/alloy/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: alloy
+  namespace: observability
+spec:
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m
+  path: "./apps/base/observability/alloy/app"
+  prune: true
+  wait: true
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+    namespace: flux-system
+  dependsOn:
+    - name: loki
+      namespace: observability
+  targetNamespace: observability

--- a/kubernetes/apps/base/observability/grafana/instance/grafanadatasource.yaml
+++ b/kubernetes/apps/base/observability/grafana/instance/grafanadatasource.yaml
@@ -31,3 +31,18 @@ spec:
     jsonData:
       implementation: prometheus
     url: http://alertmanager-operated.observability.svc.cluster.local:9093
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadatasource_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: loki
+spec:
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasource:
+    type: loki
+    name: Loki
+    access: proxy
+    url: http://loki-gateway.observability.svc.cluster.local

--- a/kubernetes/apps/base/observability/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/loki/app/helmrelease.yaml
@@ -37,53 +37,62 @@ spec:
     mode: enabled
   maxHistory: 3
   values:
+    deploymentMode: SingleBinary
     singleBinary:
       replicas: 1
-      nodeSelector:
-        openebs.io/storage: "true"
-        kubernetes.io/arch: arm64
+      persistence:
+        enabled: true
+        storageClass: ceph-block
+        size: 20Gi
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
     loki:
-      storage:
-        type: filesystem
       auth_enabled: false
       commonConfig:
         replication_factor: 1
+      storage:
+        type: filesystem
+      schemaConfig:
+        configs:
+          - from: "2024-04-01"
+            store: tsdb
+            object_store: filesystem
+            schema: v13
+            index:
+              prefix: loki_index_
+              period: 24h
       limits_config:
         retention_period: 14d
-        enforce_metric_name: false
         reject_old_samples: true
         reject_old_samples_max_age: 168h
-        max_cache_freshness_per_query: 10m
-        split_queries_by_interval: 15m
         ingestion_rate_mb: 8
         ingestion_burst_size_mb: 16
-        shard_streams:
-          enabled: true
       compactor:
-        working_directory: /var/loki/boltdb-shipper-compactor
-        shared_store: filesystem
+        working_directory: /var/loki/compactor
         compaction_interval: 10m
         retention_enabled: true
         retention_delete_delay: 2h
         retention_delete_worker_count: 150
-      ingester:
-        max_chunk_age: 1h
       analytics:
         reporting_enabled: false
+    read:
+      replicas: 0
+    write:
+      replicas: 0
+    backend:
+      replicas: 0
+    gateway:
+      replicas: 1
+    chunksCache:
+      enabled: false
+    resultsCache:
+      enabled: false
     test:
       enabled: false
-    read:
-      replicas: 1
-      # persistence:
-      #   storageClass: cstor-replica-raspberry-pi-pool
-    write:
-      replicas: 1
-      # persistence:
-      #   storageClass: cstor-replica-raspberry-pi-pool
-    backend:
-      replicas: 1
-      # persistence:
-      #   storageClass: cstor-replica-raspberry-pi-pool
     monitoring:
       dashboards:
         annotations:
@@ -94,6 +103,3 @@ spec:
           installOperator: false
       lokiCanary:
         enabled: false
-      # structuredConfig:
-      #   memberlist:
-      #     join_members: ["loki-memberlist"]

--- a/kubernetes/apps/overlays/cluster-00/kustomization.yaml
+++ b/kubernetes/apps/overlays/cluster-00/kustomization.yaml
@@ -83,7 +83,8 @@ resources:
   # - ../../base/observability/kiali/ks.yaml
   - ../../base/observability/kromgo/ks.yaml
   - ../../base/observability/kube-prometheus-stack/ks.yaml
-  # - ../../base/observability/loki/ks.yaml
+  - ../../base/observability/alloy/ks.yaml
+  - ../../base/observability/loki/ks.yaml
   # - ../../base/observability/otel/ks.yaml
   - ../../base/observability/silence-operator/ks.yaml
   - ../../base/observability/vpa/ks.yaml


### PR DESCRIPTION
## Summary
- Deploy **Loki** in SingleBinary mode with ceph-block 20Gi PVC for log storage (14d retention)
- Deploy **Grafana Alloy** as a log collector using `loki.source.kubernetes` to ship container logs to Loki
- Add **Loki GrafanaDatasource** for querying logs directly in Grafana
- Unarchive **grafana-charts HelmRepository** (required for Alloy Helm chart, no OCI registry available)

## Changes
| File | Change |
|------|--------|
| `loki/app/helmrelease.yaml` | Modernized: removed stale arm64/openebs nodeSelector, added TSDB schema v13, ceph-block persistence, resource limits, disabled unused read/write/backend replicas |
| `alloy/` (new) | New app: Alloy log collector with Kubernetes API-based pod log collection, cluster labeling, ships to Loki gateway |
| `grafana/instance/grafanadatasource.yaml` | Added Loki datasource |
| `repositories/helm/grafana-charts.yaml` | Unarchived from `archive/` |
| `overlays/cluster-00/kustomization.yaml` | Enabled Loki + Alloy |

## Architecture
```
Container Logs → Alloy (K8s API) → Loki Gateway → Loki SingleBinary (ceph-block PVC)
                                                          ↓
                                              Grafana (Loki datasource)
```

## Test plan
- [ ] Verify Loki pod starts and PVC is provisioned on ceph-block
- [ ] Verify Alloy pod starts and connects to Loki gateway
- [ ] Verify Loki datasource appears in Grafana
- [ ] Query container logs via Grafana Explore using `{namespace="observability"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)