### PR TITLE
feat: add wrangler.toml for Cloudflare Pages deploy

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,5 @@
+name = "k8s-gitops"
+compatibility_date = "2026-02-23"
+
+[assets]
+directory = "./docs"


### PR DESCRIPTION
## Summary
- Add `wrangler.toml` to configure static asset serving from `docs/` directory
- Enables the new Cloudflare Workers & Pages unified deploy with `npx wrangler deploy`

## Test plan
- [ ] Verify Cloudflare Pages deploys successfully with `npx wrangler deploy`
- [ ] Verify `owncloud.ai` serves the landing page