### PR TITLE
fix(dex): remove unsupported device responseType

### DIFF
--- a/kubernetes/apps/base/network-system/dex/app/values.yaml
+++ b/kubernetes/apps/base/network-system/dex/app/values.yaml
@@ -11,7 +11,7 @@ config:
       inCluster: true
   oauth2:
     alwaysShowLoginScreen: false
-    responseTypes: ['code', 'token', 'id_token', 'device']
+    responseTypes: ['code', 'token', 'id_token']
     skipApprovalScreen: true
   web:
     http: 0.0.0.0:5556


### PR DESCRIPTION
## Summary
- Remove `device` from `oauth2.responseTypes` — Dex v2.44.0 doesn't support it as a responseType
- This was causing Dex to crash with: `failed to initialize server: unsupported response_type "device"`
- Dex device code flow is configured separately via `oauth2.deviceCodeFlow` if needed in the future

## Test plan
- [ ] Verify Dex pod starts successfully
- [ ] Verify oauth2-proxy becomes ready (depends on Dex)
- [ ] Verify SSO login works