### PR TITLE
fix(dns): remove redundant target annotations from HTTPRoutes

### DIFF
--- a/kubernetes/apps/base/ai-system/n8n/app/httproute.yaml
+++ b/kubernetes/apps/base/ai-system/n8n/app/httproute.yaml
@@ -6,7 +6,6 @@ metadata:
   name: n8n
   annotations:
     external-dns.alpha.kubernetes.io/external: 'true'
-    external-dns.alpha.kubernetes.io/target: "external.${CLUSTER_DOMAIN}"
 spec:
   parentRefs:
     - name: envoy-external

--- a/kubernetes/apps/base/flux-system/flux-instance/extras/httproute.yaml
+++ b/kubernetes/apps/base/flux-system/flux-instance/extras/httproute.yaml
@@ -7,7 +7,6 @@ metadata:
   name: receiver
   annotations:
     external-dns.alpha.kubernetes.io/external: 'true'
-    external-dns.alpha.kubernetes.io/target: "external.${CLUSTER_DOMAIN}"
 spec:
   parentRefs:
     - name: envoy-external
@@ -31,7 +30,6 @@ metadata:
   name: flux
   annotations:
     external-dns.alpha.kubernetes.io/external: 'true'
-    external-dns.alpha.kubernetes.io/target: "external.${CLUSTER_DOMAIN}"
 spec:
   parentRefs:
     - name: envoy-external

--- a/kubernetes/apps/base/game-servers/minecraft/app/httproute.yaml
+++ b/kubernetes/apps/base/game-servers/minecraft/app/httproute.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: game-servers
   annotations:
     external-dns.alpha.kubernetes.io/external: 'true'
-    external-dns.alpha.kubernetes.io/target: "external.${CLUSTER_DOMAIN}"
 spec:
   parentRefs:
     - name: envoy-external

--- a/kubernetes/apps/base/home-system/home-assistant/app/httproute.yaml
+++ b/kubernetes/apps/base/home-system/home-assistant/app/httproute.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: home-system
   annotations:
     external-dns.alpha.kubernetes.io/external: 'true'
-    external-dns.alpha.kubernetes.io/target: "external.${CLUSTER_DOMAIN}"
 spec:
   parentRefs:
     - name: envoy-external

--- a/kubernetes/apps/base/home-system/jellyseerr/app/httproute.yaml
+++ b/kubernetes/apps/base/home-system/jellyseerr/app/httproute.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: home-system
   annotations:
     external-dns.alpha.kubernetes.io/external: 'true'
-    external-dns.alpha.kubernetes.io/target: "external.${CLUSTER_DOMAIN}"
 spec:
   parentRefs:
     - name: envoy-external

--- a/kubernetes/apps/base/network-system/dex-k8s-authenticator/app/httproute.yaml
+++ b/kubernetes/apps/base/network-system/dex-k8s-authenticator/app/httproute.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: network-system
   annotations:
     external-dns.alpha.kubernetes.io/external: 'true'
-    external-dns.alpha.kubernetes.io/target: "external.${CLUSTER_DOMAIN}"
 spec:
   parentRefs:
     - name: envoy-external

--- a/kubernetes/apps/base/network-system/dex/app/httproute.yaml
+++ b/kubernetes/apps/base/network-system/dex/app/httproute.yaml
@@ -6,7 +6,6 @@ metadata:
   name: dex
   annotations:
     external-dns.alpha.kubernetes.io/external: 'true'
-    external-dns.alpha.kubernetes.io/target: "external.${CLUSTER_DOMAIN}"
 spec:
   parentRefs:
     - name: envoy-external

--- a/kubernetes/apps/base/network-system/oauth2-proxy/app/httproute.yaml
+++ b/kubernetes/apps/base/network-system/oauth2-proxy/app/httproute.yaml
@@ -6,7 +6,6 @@ metadata:
   name: auth
   annotations:
     external-dns.alpha.kubernetes.io/external: 'true'
-    external-dns.alpha.kubernetes.io/target: "external.${CLUSTER_DOMAIN}"
 spec:
   parentRefs:
     - name: envoy-external

--- a/kubernetes/apps/base/observability/grafana/instance/httproute.yaml
+++ b/kubernetes/apps/base/observability/grafana/instance/httproute.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: observability
   annotations:
     external-dns.alpha.kubernetes.io/external: 'true'
-    external-dns.alpha.kubernetes.io/target: "external.${CLUSTER_DOMAIN}"
 spec:
   parentRefs:
     - name: envoy-external

--- a/kubernetes/apps/base/observability/kromgo/app/httproute.yaml
+++ b/kubernetes/apps/base/observability/kromgo/app/httproute.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: observability
   annotations:
     external-dns.alpha.kubernetes.io/external: 'true'
-    external-dns.alpha.kubernetes.io/target: "external.${CLUSTER_DOMAIN}"
 spec:
   parentRefs:
     - name: envoy-external


### PR DESCRIPTION
## Summary

- Remove `external-dns.alpha.kubernetes.io/target` from 10 HTTPRoute files
- The target is already set on the `envoy-external` Gateway and inherited by attached routes
- The `external-dns.alpha.kubernetes.io/external` filter annotation is kept