### PR TITLE
fix(flux): sync ResourceSet OCIRepository tags and add renovate tracking

### DIFF
--- a/kubernetes/clusters/cluster-00/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/clusters/cluster-00/flux-system/flux-instance/app/helmrelease.yaml
@@ -22,7 +22,8 @@ spec:
         interval: 10m
         url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance
         ref:
-          tag: '0.39.0'
+          # renovate: datasource=docker depName=ghcr.io/controlplaneio-fluxcd/charts/flux-instance
+          tag: 0.42.1
         verify:
           provider: cosign
           matchOIDCIdentity:

--- a/kubernetes/clusters/cluster-00/flux-system/flux-operator/app/helmrelease.yaml
+++ b/kubernetes/clusters/cluster-00/flux-system/flux-operator/app/helmrelease.yaml
@@ -22,7 +22,8 @@ spec:
         interval: 10m
         url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
         ref:
-          tag: '0.39.0'
+          # renovate: datasource=docker depName=ghcr.io/controlplaneio-fluxcd/charts/flux-operator
+          tag: 0.42.1
         verify:
           provider: cosign
           matchOIDCIdentity:


### PR DESCRIPTION
## Summary
- Update OCIRepository tags in flux-operator and flux-instance ResourceSet files from `0.39.0` to `0.42.1`
- Add `# renovate:` annotations so the custom regex manager tracks these tags going forward

## Problem
Renovate's built-in `flux` manager doesn't understand the `ResourceSet` CRD, so the embedded OCIRepository `ref.tag` values were stuck at `0.39.0` while helmfile and distribution artifact were updated to `0.42.1`.