### PR TITLE
feat: add Ollama for CPU-based LLM inference

### DIFF
--- a/kubernetes/apps/base/ai-system/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/base/ai-system/ollama/app/helmrelease.yaml
@@ -1,0 +1,61 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ollama
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: ollama
+      version: 1.46.0
+      sourceRef:
+        kind: HelmRepository
+        name: ollama-charts
+        namespace: flux-system
+      interval: 10m
+  install:
+    timeout: 10m
+    replace: true
+    crds: CreateReplace
+    createNamespace: true
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  upgrade:
+    remediation:
+      remediateLastFailure: true
+      retries: 3
+      strategy: rollback
+    cleanupOnFail: true
+    crds: CreateReplace
+  test:
+    enable: true
+  rollback:
+    recreate: true
+    force: true
+    cleanupOnFail: true
+  uninstall:
+    keepHistory: false
+  driftDetection:
+    mode: enabled
+  maxHistory: 3
+  values:
+    replicaCount: 1
+    ollama:
+      gpu:
+        enabled: false
+      models:
+        pull:
+          - qwen2.5:3b
+    resources:
+      requests:
+        cpu: 500m
+        memory: 4Gi
+      limits:
+        memory: 8Gi
+    persistentVolume:
+      enabled: true
+      storageClass: ceph-block
+      size: 30Gi

--- a/kubernetes/apps/base/ai-system/ollama/app/httproute.yaml
+++ b/kubernetes/apps/base/ai-system/ollama/app/httproute.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ollama
+  namespace: ai-system
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network-system
+      sectionName: https
+  hostnames:
+    - 'ollama.${CLUSTER_DOMAIN}'
+  rules:
+    - backendRefs:
+        - name: ollama
+          port: 11434
+          weight: 100

--- a/kubernetes/apps/base/ai-system/ollama/app/kustomization.yaml
+++ b/kubernetes/apps/base/ai-system/ollama/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - helmrelease.yaml
+  - httproute.yaml

--- a/kubernetes/apps/base/ai-system/ollama/ks.yaml
+++ b/kubernetes/apps/base/ai-system/ollama/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ollama
+  namespace: ai-system
+spec:
+  decryption:
+    provider: sops
+  interval: 30m
+  retryInterval: 1m
+  timeout: 3m
+  path: "./apps/base/ai-system/ollama/app"
+  prune: true
+  wait: true
+  sourceRef:
+    kind: OCIRepository
+    name: flux-system
+    namespace: flux-system
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  targetNamespace: ai-system

--- a/kubernetes/apps/base/flux-system/repositories/helm/kustomization.yaml
+++ b/kubernetes/apps/base/flux-system/repositories/helm/kustomization.yaml
@@ -15,4 +15,5 @@ resources:
   - ingress-nginx-chart.yaml
   - loft-charts.yaml
   - minecraft-server-charts.yaml
+  - ollama-charts.yaml
   - openfeature-charts.yaml

--- a/kubernetes/apps/base/flux-system/repositories/helm/ollama-charts.yaml
+++ b/kubernetes/apps/base/flux-system/repositories/helm/ollama-charts.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ollama-charts
+  namespace: flux-system
+spec:
+  interval: 2h
+  url: https://helm.otwld.com

--- a/kubernetes/apps/overlays/cluster-00/kustomization.yaml
+++ b/kubernetes/apps/overlays/cluster-00/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
   - ../../base/ai-system/kgateway/ks.yaml
   - ../../base/ai-system/kmcp/ks.yaml
   - ../../base/ai-system/n8n/ks.yaml
+  - ../../base/ai-system/ollama/ks.yaml
   # - ../../base/crossplane-system/crossplane/ks.yaml
   - ../../base/democratic-csi/democratic-csi/ks.yaml
   # - ../../base/development/backstage/ks.yaml


### PR DESCRIPTION
## Summary
- **Ollama** (v1.46.0): CPU-only LLM inference in `ai-system` with qwen2.5:3b, Ceph storage, and internal HTTPRoute