### PR TITLE
fix(vmangos): add missing RealmID to mangosd.conf

### DIFF
--- a/kubernetes/apps/base/game-servers/vmangos/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/vmangos/app/helmrelease.yaml
@@ -198,6 +198,7 @@ spec:
             WorldDatabase.Info = "vmangos-database;3306;mangos;mangos;mangos"
             CharacterDatabase.Info = "vmangos-database;3306;mangos;mangos;characters"
             LogsDatabase.Info = "vmangos-database;3306;mangos;mangos;logs"
+            RealmID = 1
             WorldServerPort = 8085
             BindIP = "0.0.0.0"
             WowPatch = 10


### PR DESCRIPTION
Mangosd is in CrashLoopBackOff due to missing RealmID config. Also updated realm address in DB to envoy gateway IP.