### PR TITLE
feat(enemy-territory): enable server discoverability

### DIFF
--- a/kubernetes/apps/base/game-servers/enemy-territory/app/configmap.yaml
+++ b/kubernetes/apps/base/game-servers/enemy-territory/app/configmap.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: game-servers
 data:
   server.cfg: |
+    // server discoverability
+    set sv_advert 1
+    set net_ip "${EXTERNAL_IP}"
+
     // run etpub nodl config
     exec hs_etpub.cfg
   etconfig.cfg: |

--- a/kubernetes/apps/base/game-servers/enemy-territory/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/enemy-territory/app/helmrelease.yaml
@@ -85,7 +85,6 @@ spec:
             readOnly: true
           - path: /etlegacy/legacy/etconfig.cfg
             subPath: etconfig.cfg
-            readOnly: true
           - path: /etlegacy/legacy/campaigncycle.cfg
             subPath: campaigncycle.cfg
             readOnly: true
@@ -107,4 +106,3 @@ spec:
         globalMounts:
           - path: /etlegacy/legacy/hs_etpub.cfg
             subPath: hs_etpub.cfg
-            readOnly: true

--- a/kubernetes/apps/base/game-servers/enemy-territory/app/kustomization.yaml
+++ b/kubernetes/apps/base/game-servers/enemy-territory/app/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - helmrelease.yaml
   - configmap.yaml
   - secret.enc.age.yaml
+  - network-secret.enc.age.yaml
   - pvc.yaml
   - udproute.yaml

--- a/kubernetes/apps/base/game-servers/enemy-territory/app/network-secret.enc.age.yaml
+++ b/kubernetes/apps/base/game-servers/enemy-territory/app/network-secret.enc.age.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: enemy-territory-network
+  namespace: game-servers
+type: Opaque
+stringData:
+  EXTERNAL_IP: ENC[AES256_GCM,data:XO2o1BQT6fuRCuJr,iv:qcCtQtZdpTjADxSFcGPiyTHcGv9ECdLtktIssZkilGs=,tag:5HKdo4sj0FlgdPQjQoCQoA==,type:str]
+sops:
+  age:
+    - recipient: age19gj66fq5v2veu940ftyj4pkw0w5tgxgddlyqnd00pnjzyndevurqx70g4t
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPa25nS2M5bGdKUlVkUVRk
+        TEh4Z1NrclpjQ04wNi9DRVY3ZU0yVW9Iemw0CjFkaXN5MTlwY01vUlBNcnh5bzB0
+        T1lIL1c4UWtMWmdrd3JaNml0ZmZyMUkKLS0tIDM4QlU0Z3pJVzZaRnJlZE1wcWVR
+        VHRDQkFvcmFFM3VaOTVESVkySXRUWFkKjhohx8luNSi4Sus6bmlVO4298xoFJbxT
+        zCjnIKAgVYf0BuJ09lhKw7nLX1Oile5c3hNREH4EEHa081sSkg4IzQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-02-28T12:26:24Z"
+  mac: ENC[AES256_GCM,data:SrNJKHQmAeoDWfBzOstpGpuUeQU1Xeoge/yMGovho2udf3jUcYDC7AfPjSD/8h81BCRU4nxw2l7eHNrbVr0la++EGMjWb45FRsMafjEHX1H0BnWQ8duPYr3jMjhU685FnzrImwHtKAjcNNBlBZtxAD7ok5xxmPA3MYu1Nk8Efk8=,iv:1pUz86TWgR5ul66yOPGs7d/RRrB+txDlNSRnVMxSpOA=,tag:SupUW4y3RjRUwSeW3nPcVw==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.12.1

--- a/kubernetes/apps/base/game-servers/enemy-territory/ks.yaml
+++ b/kubernetes/apps/base/game-servers/enemy-territory/ks.yaml
@@ -20,3 +20,7 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: game-servers
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: enemy-territory-network


### PR DESCRIPTION
Enable ET Legacy server to appear in public game server browser.

- Add `sv_advert 1` to enable heartbeat responses to master servers
- Add `net_ip` via Flux postBuild substitution from SOPS-encrypted secret
- Remove `readOnly` from `etconfig.cfg` and `hs_etpub.cfg` mounts (game engine and rcon need write access)