### PR TITLE
fix(enemy-territory): pass sv_advert and net_ip as startup args

### DIFF
--- a/kubernetes/apps/base/game-servers/enemy-territory/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/enemy-territory/app/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
               repository: xunholy/enemy-territory
               tag: sha-214208b
             command: ["/bin/bash", "-c", "--"]
-            args: ["/etlegacy/start.sh"]
+            args: ["/etlegacy/etlded.x86_64 +set dedicated 2 +set vm_game 0 +set net_port 27960 +set sv_maxclients 20 +set fs_game legacy +set sv_punkbuster 0 +set fs_basepath /etlegacy +set fs_homepath /etlegacy +set sv_advert 1 +set net_ip ${EXTERNAL_IP} +exec server.cfg"]
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: false


### PR DESCRIPTION
sv_advert and net_ip must be set before network init. Passing them as
startup arguments to etlded instead of in server.cfg so they take effect
before the engine opens the UDP socket.

- `sv_advert 1` enables heartbeat responses to master servers
- `net_ip` set via Flux postBuild substitution from SOPS-encrypted secret