### PR TITLE
fix(enemy-territory): fix args parsing and EXTERNAL_IP substitution

### DIFF
--- a/kubernetes/apps/base/game-servers/enemy-territory/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/enemy-territory/app/helmrelease.yaml
@@ -45,19 +45,21 @@ spec:
             image:
               repository: xunholy/enemy-territory
               tag: sha-214208b
-            command: ["/etlegacy/etlded.x86_64"]
+            command: ["/bin/bash", "-c", "--"]
             args:
-              - +set dedicated 2
-              - +set net_ip ${EXTERNAL_IP}
-              - +set net_port 27960
-              - +set sv_advert 3
-              - +set vm_game 0
-              - +set fs_basepath /etlegacy
-              - +set fs_homepath /config
-              - +set fs_game legacy
-              - +set sv_maxclients 20
-              - +set sv_punkbuster 0
-              - +exec server.cfg
+              - >-
+                /etlegacy/etlded.x86_64
+                +set dedicated 2
+                +set net_ip ${EXTERNAL_IP}
+                +set net_port 27960
+                +set sv_advert 3
+                +set vm_game 0
+                +set fs_basepath /etlegacy
+                +set fs_homepath /config
+                +set fs_game legacy
+                +set sv_maxclients 20
+                +set sv_punkbuster 0
+                +exec server.cfg
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: false


### PR DESCRIPTION
YAML list args were passed as individual argv strings, causing trailing spaces in paths (`/config  /legacy  `). Use a single folded scalar through bash instead.