### PR TITLE
feat: auto-merge minor helm updates with flux rollback workflow

### DIFF
--- a/.github/workflows/flux-rollback.yaml
+++ b/.github/workflows/flux-rollback.yaml
@@ -1,0 +1,175 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: "Flux HelmRelease Rollback"
+
+on:
+  repository_dispatch:
+    types:
+      - HelmRelease/*
+
+concurrency:
+  group: flux-rollback
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  rollback:
+    name: Create Revert PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Parse Flux Event
+        id: event
+        env:
+          PAYLOAD: ${{ toJSON(github.event.client_payload) }}
+        run: |
+          INVOLVED_OBJECT=$(echo "$PAYLOAD" | jq -r '.involvedObject.name // empty')
+          NAMESPACE=$(echo "$PAYLOAD" | jq -r '.involvedObject.namespace // empty')
+          SEVERITY=$(echo "$PAYLOAD" | jq -r '.severity // empty')
+          MESSAGE=$(echo "$PAYLOAD" | jq -r '.message // empty')
+          REVISION=$(echo "$PAYLOAD" | jq -r '.metadata.revision // empty')
+
+          echo "helmrelease=$INVOLVED_OBJECT" >> "$GITHUB_OUTPUT"
+          echo "namespace=$NAMESPACE" >> "$GITHUB_OUTPUT"
+          echo "severity=$SEVERITY" >> "$GITHUB_OUTPUT"
+          echo "message=$MESSAGE" >> "$GITHUB_OUTPUT"
+          echo "revision=$REVISION" >> "$GITHUB_OUTPUT"
+
+          echo "::notice::HelmRelease $NAMESPACE/$INVOLVED_OBJECT failed: $MESSAGE"
+
+      - name: Find Renovate Commit to Revert
+        id: find-commit
+        env:
+          HELMRELEASE: ${{ steps.event.outputs.helmrelease }}
+          NAMESPACE: ${{ steps.event.outputs.namespace }}
+        run: |
+          # Find the most recent Renovate auto-merge commit that touched files
+          # related to this HelmRelease
+          COMMIT_SHA=$(git log --oneline --all --author="renovate" \
+            --grep="$HELMRELEASE" -1 --format="%H" -- 'kubernetes/')
+
+          if [ -z "$COMMIT_SHA" ]; then
+            # Fallback: search by path pattern for the HelmRelease name
+            COMMIT_SHA=$(git log --oneline --all --author="renovate" \
+              -1 --format="%H" -- "kubernetes/apps/base/**/$HELMRELEASE/**")
+          fi
+
+          if [ -z "$COMMIT_SHA" ]; then
+            echo "::warning::No Renovate commit found for HelmRelease $HELMRELEASE, skipping revert"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          COMMIT_MSG=$(git log -1 --format="%s" "$COMMIT_SHA")
+          echo "sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
+          echo "message=$COMMIT_MSG" >> "$GITHUB_OUTPUT"
+          echo "found=true" >> "$GITHUB_OUTPUT"
+
+          # Detect grouped Renovate commits
+          FILE_COUNT=$(git diff-tree --no-commit-id --name-only -r "$COMMIT_SHA" | wc -l)
+          if [ "$FILE_COUNT" -gt 3 ]; then
+            echo "grouped=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "grouped=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "::notice::Found Renovate commit $COMMIT_SHA: $COMMIT_MSG (files changed: $FILE_COUNT)"
+
+      - name: Create Revert Branch
+        if: steps.find-commit.outputs.found == 'true'
+        id: revert
+        env:
+          COMMIT_SHA: ${{ steps.find-commit.outputs.sha }}
+          HELMRELEASE: ${{ steps.event.outputs.helmrelease }}
+        run: |
+          BRANCH="revert/flux-rollback-${HELMRELEASE}-$(date +%s)"
+          git checkout -b "$BRANCH"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if ! git revert --no-edit "$COMMIT_SHA"; then
+            echo "::error::Failed to revert commit $COMMIT_SHA - may have conflicts"
+            echo "reverted=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "reverted=true" >> "$GITHUB_OUTPUT"
+
+      - name: Build PR Body
+        if: steps.find-commit.outputs.found == 'true' && steps.revert.outputs.reverted == 'true'
+        id: pr-body
+        env:
+          HELMRELEASE: ${{ steps.event.outputs.helmrelease }}
+          NAMESPACE: ${{ steps.event.outputs.namespace }}
+          COMMIT_SHA: ${{ steps.find-commit.outputs.sha }}
+          COMMIT_MSG: ${{ steps.find-commit.outputs.message }}
+          GROUPED: ${{ steps.find-commit.outputs.grouped }}
+          FLUX_MESSAGE: ${{ steps.event.outputs.message }}
+        run: |
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+
+          GROUPED_WARNING=""
+          if [ "$GROUPED" = "true" ]; then
+            GROUPED_WARNING=$(cat <<'WARN'
+
+          > [!CAUTION]
+          > This reverts a **grouped Renovate commit** that touched multiple HelmReleases.
+          > Merging this PR will revert all changes in the group, not just the failing release.
+          > Consider manual triage instead.
+          WARN
+          )
+          fi
+
+          cat <<BODY > pr-body.md
+          ## Flux Automatic Rollback
+
+          HelmRelease \`$NAMESPACE/$HELMRELEASE\` failed to upgrade after an auto-merged Renovate update.
+
+          **Flux error:** $FLUX_MESSAGE
+
+          **Reverted commit:** [\`$SHORT_SHA\`](https://github.com/xunholy/k8s-gitops/commit/$COMMIT_SHA) — $COMMIT_MSG
+          $GROUPED_WARNING
+
+          ### What happened
+          1. Renovate auto-merged a minor/patch update
+          2. Flux deployed the change via OCI artifact
+          3. HelmRelease upgrade failed after all retries
+          4. Flux rolled back the release in-cluster
+          5. This PR was created to revert the git state
+
+          ### Next steps
+          - [ ] Review the failure cause
+          - [ ] Merge this PR to align git state with cluster state
+          - [ ] Investigate the upstream chart release for breaking changes
+          BODY
+
+      - name: Create Revert PR
+        if: steps.find-commit.outputs.found == 'true' && steps.revert.outputs.reverted == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HELMRELEASE: ${{ steps.event.outputs.helmrelease }}
+          BRANCH: ${{ steps.revert.outputs.branch }}
+        run: |
+          gh pr create \
+            --title "revert: rollback $HELMRELEASE due to upgrade failure" \
+            --draft \
+            --label "flux/rollback" \
+            --head "$BRANCH" \
+            --body-file pr-body.md

--- a/.github/workflows/flux-rollback.yaml
+++ b/.github/workflows/flux-rollback.yaml
@@ -3,12 +3,10 @@
 name: "Flux HelmRelease Rollback"
 
 on:
-  repository_dispatch:
-    types:
-      - HelmRelease/*
+  repository_dispatch: {}
 
 concurrency:
-  group: flux-rollback
+  group: flux-rollback-${{ github.event.client_payload.involvedObject.name }}
   cancel-in-progress: false
 
 permissions:
@@ -17,6 +15,7 @@ permissions:
 jobs:
   rollback:
     name: Create Revert PR
+    if: startsWith(github.event.action, 'HelmRelease')
     runs-on: ubuntu-latest
     steps:
       - name: Generate Token
@@ -41,13 +40,11 @@ jobs:
           NAMESPACE=$(echo "$PAYLOAD" | jq -r '.involvedObject.namespace // empty')
           SEVERITY=$(echo "$PAYLOAD" | jq -r '.severity // empty')
           MESSAGE=$(echo "$PAYLOAD" | jq -r '.message // empty')
-          REVISION=$(echo "$PAYLOAD" | jq -r '.metadata.revision // empty')
 
           echo "helmrelease=$INVOLVED_OBJECT" >> "$GITHUB_OUTPUT"
           echo "namespace=$NAMESPACE" >> "$GITHUB_OUTPUT"
           echo "severity=$SEVERITY" >> "$GITHUB_OUTPUT"
           echo "message=$MESSAGE" >> "$GITHUB_OUTPUT"
-          echo "revision=$REVISION" >> "$GITHUB_OUTPUT"
 
           echo "::notice::HelmRelease $NAMESPACE/$INVOLVED_OBJECT failed: $MESSAGE"
 
@@ -55,17 +52,21 @@ jobs:
         id: find-commit
         env:
           HELMRELEASE: ${{ steps.event.outputs.helmrelease }}
-          NAMESPACE: ${{ steps.event.outputs.namespace }}
         run: |
-          # Find the most recent Renovate auto-merge commit that touched files
-          # related to this HelmRelease
-          COMMIT_SHA=$(git log --oneline --all --author="renovate" \
-            --grep="$HELMRELEASE" -1 --format="%H" -- 'kubernetes/')
+          # Find the HelmRelease directory under kubernetes/apps/base
+          APP_PATH=$(find kubernetes/apps/base -type d -name "$HELMRELEASE" | head -1)
+
+          COMMIT_SHA=""
+          if [ -n "$APP_PATH" ]; then
+            # Find the most recent Renovate commit touching this HelmRelease's files
+            COMMIT_SHA=$(git log --author="renovate\[bot\]" \
+              -1 --format="%H" -- "$APP_PATH/")
+          fi
 
           if [ -z "$COMMIT_SHA" ]; then
-            # Fallback: search by path pattern for the HelmRelease name
-            COMMIT_SHA=$(git log --oneline --all --author="renovate" \
-              -1 --format="%H" -- "kubernetes/apps/base/**/$HELMRELEASE/**")
+            # Fallback: glob search across all base directories
+            COMMIT_SHA=$(git log --author="renovate\[bot\]" \
+              -1 --format="%H" -- ":(glob)kubernetes/apps/base/**/$HELMRELEASE/**")
           fi
 
           if [ -z "$COMMIT_SHA" ]; then
@@ -96,11 +97,11 @@ jobs:
           COMMIT_SHA: ${{ steps.find-commit.outputs.sha }}
           HELMRELEASE: ${{ steps.event.outputs.helmrelease }}
         run: |
-          BRANCH="revert/flux-rollback-${HELMRELEASE}-$(date +%s)"
-          git checkout -b "$BRANCH"
-
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          BRANCH="revert/flux-rollback-${HELMRELEASE}-${COMMIT_SHA:0:7}"
+          git checkout -b "$BRANCH"
 
           if ! git revert --no-edit "$COMMIT_SHA"; then
             echo "::error::Failed to revert commit $COMMIT_SHA - may have conflicts"
@@ -114,7 +115,6 @@ jobs:
 
       - name: Build PR Body
         if: steps.find-commit.outputs.found == 'true' && steps.revert.outputs.reverted == 'true'
-        id: pr-body
         env:
           HELMRELEASE: ${{ steps.event.outputs.helmrelease }}
           NAMESPACE: ${{ steps.event.outputs.namespace }}
@@ -169,7 +169,7 @@ jobs:
         run: |
           gh pr create \
             --title "revert: rollback $HELMRELEASE due to upgrade failure" \
+            --base main \
             --draft \
-            --label "flux/rollback" \
             --head "$BRANCH" \
             --body-file pr-body.md

--- a/.renovate/autoMerge.json5
+++ b/.renovate/autoMerge.json5
@@ -10,12 +10,11 @@
       ignoreTests: true
     },
     {
-      description: "Auto-merge Helm Release",
+      description: "Auto-merge Helm Release (minor and patch)",
       matchDatasources: ["helm", "docker"],
       automerge: true,
       automergeType: "pr",
-      matchUpdateTypes: ["patch"],
-      ignoreTests: true
+      matchUpdateTypes: ["minor", "patch"]
     }
   ]
 }

--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -95,6 +95,7 @@
       groupName: "kgateway",
       matchDatasources: ["helm"],
       matchPackagePatterns: ["kgateway", "kgateway-crds"],
+      automerge: false,
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
@@ -143,6 +144,7 @@
       groupName: "1password-connect",
       matchDatasources: ["docker"],
       matchPackageNames: ["/1password/"],
+      automerge: false,
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },

--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -19,6 +19,7 @@
       groupName: "talos",
       matchDatasources: ["docker"],
       matchPackageNames: ["/installer/"],
+      automerge: false,
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
@@ -29,6 +30,7 @@
       groupName: "istio",
       matchDatasources: ["helm"],
       matchPackagePatterns: ["gateway", "istio-base", "istio-cni", "istiod"],
+      automerge: false,
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
@@ -39,6 +41,7 @@
       groupName: "Cilium",
       matchDatasources: ["docker"],
       matchPackageNames: ["/cilium/"],
+      automerge: false,
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
@@ -52,6 +55,7 @@
         "/flux-instance/",
         "/flux-operator-manifests/",
       ],
+      automerge: false,
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
@@ -101,6 +105,7 @@
       groupName: "rook-ceph",
       matchDatasources: ["docker"],
       matchPackageNames: ["/rook-ceph/", "/rook-ceph-cluster/"],
+      automerge: false,
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
@@ -117,6 +122,7 @@
         "/kube-scheduler/",
         "/kubelet/",
       ],
+      automerge: false,
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },

--- a/kubernetes/components/common/alerts/github-dispatch/alert.yaml
+++ b/kubernetes/components/common/alerts/github-dispatch/alert.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/notification.toolkit.fluxcd.io/alert_v1beta3.json
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: helmrelease-rollback
+  namespace: flux-system
+spec:
+  summary: HelmRelease upgrade failure requiring git rollback
+  providerRef:
+    name: github-dispatch
+  eventSeverity: error
+  eventSources:
+    - kind: HelmRelease
+      name: "*"
+  inclusionList:
+    - ".*upgrade.*failed.*"

--- a/kubernetes/components/common/alerts/github-dispatch/externalsecret.yaml
+++ b/kubernetes/components/common/alerts/github-dispatch/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-dispatch-token
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: github-dispatch-token-secret
+    template:
+      data:
+        token: "{{ .FLUX_GITHUB_DISPATCH_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: flux

--- a/kubernetes/components/common/alerts/github-dispatch/kustomization.yaml
+++ b/kubernetes/components/common/alerts/github-dispatch/kustomization.yaml
@@ -4,5 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ./github
-  - ./github-dispatch
+  - alert.yaml
+  - externalsecret.yaml
+  - provider.yaml

--- a/kubernetes/components/common/alerts/github-dispatch/provider.yaml
+++ b/kubernetes/components/common/alerts/github-dispatch/provider.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/notification.toolkit.fluxcd.io/provider_v1beta3.json
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: github-dispatch
+  namespace: flux-system
+spec:
+  type: githubdispatch
+  address: https://github.com/xunholy/k8s-gitops
+  secretRef:
+    name: github-dispatch-token-secret


### PR DESCRIPTION
## Summary
- **Extend Renovate auto-merge** from patch-only to minor+patch for Helm/Docker datasources, with `ignoreTests` removed so CI (`flux-local` diff) runs before merge
- **Exclude high-risk groups** from auto-merge: Istio, Cilium, Flux Operator, Talos, Rook-Ceph, and Kubernetes groups get explicit `automerge: false`
- **Add Flux `githubdispatch` Provider + Alert** that fires on HelmRelease upgrade failures, triggering a GitHub Actions `repository_dispatch` event
- **Add GitHub Actions rollback workflow** that receives the dispatch, identifies the Renovate commit, and creates a draft revert PR with grouped-commit warnings

## How It Works
```
Renovate PR (minor/patch) → auto-merge → Flux deploys via OCI
  ├─ Success: done
  └─ Failure: Flux retries 3x → rolls back in-cluster
              └─ Alert fires → githubdispatch → GitHub Actions
                 └─ Creates draft revert PR to align git state
```

## Files Changed
| File | Change |
|---|---|
| `.renovate/autoMerge.json5` | Add `minor` to matchUpdateTypes, remove `ignoreTests` |
| `.renovate/groups.json5` | Add `automerge: false` on 6 high-risk groups |
| `kubernetes/components/common/alerts/github-dispatch/` | New Flux Provider (githubdispatch) + Alert + ExternalSecret |
| `kubernetes/components/common/alerts/kustomization.yaml` | Include new github-dispatch component |
| `.github/workflows/flux-rollback.yaml` | New repository_dispatch workflow for revert PRs |

## Prerequisites
- A `FLUX_GITHUB_DISPATCH_TOKEN` key must be added to the `flux` 1Password item with a token that has the `workflow` permission scope (the existing `FLUX_GITHUB_TOKEN` may only have `repo:status`)
- The `flux/rollback` label should be created in the repo for PR labeling

## Test plan
- [ ] Verify Renovate creates PRs with minor updates and auto-merges after CI passes
- [ ] Verify high-risk groups (Istio, Cilium, etc.) are NOT auto-merged
- [ ] Verify the `FLUX_GITHUB_DISPATCH_TOKEN` is provisioned in 1Password with `workflow` scope
- [ ] Verify Flux Alert + Provider deploy correctly and the notification-controller logs show the dispatch provider registered
- [ ] Simulate a HelmRelease failure and verify the rollback workflow triggers and creates a draft revert PR
- [ ] Verify concurrency group prevents duplicate revert PRs for the same failure