### PR TITLE
feat(flux): ArtifactGenerator for monorepo decomposition

### DIFF
--- a/kubernetes/apps/base/actions-runner-system/gha-runner-scale-set-controller/ks.yaml
+++ b/kubernetes/apps/base/actions-runner-system/gha-runner-scale-set-controller/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: actions-runner-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: gha-runner-scale-set-controller
     namespace: flux-system

--- a/kubernetes/apps/base/actions-runner-system/gha-runner-scale-set/ks.yaml
+++ b/kubernetes/apps/base/actions-runner-system/gha-runner-scale-set/ks.yaml
@@ -15,6 +15,6 @@ spec:
   wait: true
   targetNamespace: actions-runner-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: actions-runner-scale-set
     namespace: flux-system

--- a/kubernetes/apps/base/ai-system/kagent/ks.yaml
+++ b/kubernetes/apps/base/ai-system/kagent/ks.yaml
@@ -13,8 +13,8 @@ spec:
       namespace: ai-system
   targetNamespace: ai-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: kagent
     namespace: flux-system
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
@@ -28,6 +28,6 @@ spec:
   wait: false
   targetNamespace: ai-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: kagent-crds
     namespace: flux-system

--- a/kubernetes/apps/base/ai-system/kgateway/ks.yaml
+++ b/kubernetes/apps/base/ai-system/kgateway/ks.yaml
@@ -13,8 +13,8 @@ spec:
       namespace: ai-system
   targetNamespace: ai-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: kgateway
     namespace: flux-system
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
@@ -28,6 +28,6 @@ spec:
   wait: false
   targetNamespace: ai-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: kgateway-crds
     namespace: flux-system

--- a/kubernetes/apps/base/ai-system/kmcp/ks.yaml
+++ b/kubernetes/apps/base/ai-system/kmcp/ks.yaml
@@ -13,8 +13,8 @@ spec:
       namespace: ai-system
   targetNamespace: ai-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: kmcp
     namespace: flux-system
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
@@ -28,6 +28,6 @@ spec:
   wait: false
   targetNamespace: ai-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: kmcp-crds
     namespace: flux-system

--- a/kubernetes/apps/base/ai-system/n8n/ks.yaml
+++ b/kubernetes/apps/base/ai-system/n8n/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: false
   targetNamespace: ai-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: n8n
     namespace: flux-system

--- a/kubernetes/apps/base/ai-system/ollama/ks.yaml
+++ b/kubernetes/apps/base/ai-system/ollama/ks.yaml
@@ -13,6 +13,6 @@ spec:
       namespace: rook-ceph
   targetNamespace: ai-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: ollama
     namespace: flux-system

--- a/kubernetes/apps/base/ai-system/open-webui/ks.yaml
+++ b/kubernetes/apps/base/ai-system/open-webui/ks.yaml
@@ -13,6 +13,6 @@ spec:
       namespace: ai-system
   targetNamespace: ai-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: open-webui
     namespace: flux-system

--- a/kubernetes/apps/base/ai-system/openclaw/ks.yaml
+++ b/kubernetes/apps/base/ai-system/openclaw/ks.yaml
@@ -17,6 +17,6 @@ spec:
       namespace: volsync-system
   targetNamespace: ai-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: openclaw
     namespace: flux-system

--- a/kubernetes/apps/base/crossplane-system/crossplane/ks.yaml
+++ b/kubernetes/apps/base/crossplane-system/crossplane/ks.yaml
@@ -10,8 +10,8 @@ spec:
   wait: true
   targetNamespace: crossplane-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: crossplane
     namespace: flux-system
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
@@ -28,6 +28,6 @@ spec:
       namespace: crossplane-system
   targetNamespace: crossplane-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: crossplane-providers
     namespace: flux-system

--- a/kubernetes/apps/base/democratic-csi/democratic-csi/ks.yaml
+++ b/kubernetes/apps/base/democratic-csi/democratic-csi/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: democratic-csi
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: democratic-csi
     namespace: flux-system

--- a/kubernetes/apps/base/development/backstage/ks.yaml
+++ b/kubernetes/apps/base/development/backstage/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: development
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: backstage
     namespace: flux-system

--- a/kubernetes/apps/base/development/open-feature-operator/ks.yaml
+++ b/kubernetes/apps/base/development/open-feature-operator/ks.yaml
@@ -13,6 +13,6 @@ spec:
       namespace: network-system
   targetNamespace: development
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: open-feature-operator
     namespace: flux-system

--- a/kubernetes/apps/base/development/vcluster/ks.yaml
+++ b/kubernetes/apps/base/development/vcluster/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: development
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: vcluster
     namespace: flux-system

--- a/kubernetes/apps/base/external-secrets/external-secrets/ks.yaml
+++ b/kubernetes/apps/base/external-secrets/external-secrets/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: external-secrets
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: external-secrets
     namespace: flux-system

--- a/kubernetes/apps/base/external-secrets/onepassword/ks.yaml
+++ b/kubernetes/apps/base/external-secrets/onepassword/ks.yaml
@@ -13,6 +13,6 @@ spec:
     - name: external-secrets
       namespace: external-secrets
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: onepassword
     namespace: flux-system

--- a/kubernetes/apps/base/flux-system/artifact-generator/artifactgenerator.yaml
+++ b/kubernetes/apps/base/flux-system/artifact-generator/artifactgenerator.yaml
@@ -1,0 +1,472 @@
+---
+apiVersion: source.extensions.fluxcd.io/v1beta1
+kind: ArtifactGenerator
+metadata:
+  name: k8s-gitops
+  namespace: flux-system
+spec:
+  sources:
+    - alias: repo
+      kind: OCIRepository
+      name: flux-system
+  artifacts:
+    - name: actions-runner-scale-set
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/actions-runner-system/gha-runner-scale-set/app/"
+          to: "@artifact/apps/base/actions-runner-system/gha-runner-scale-set/app/"
+    - name: autobrr
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/home-system/autobrr/app/"
+          to: "@artifact/apps/base/home-system/autobrr/app/"
+    - name: azerothcore-registration
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/game-servers/azerothcore-registration/app/"
+          to: "@artifact/apps/base/game-servers/azerothcore-registration/app/"
+    - name: azerothcore
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/game-servers/azerothcore/app/"
+          to: "@artifact/apps/base/game-servers/azerothcore/app/"
+    - name: backstage
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/development/backstage/app/"
+          to: "@artifact/apps/base/development/backstage/app/"
+    - name: bazarr
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/home-system/bazarr/app/"
+          to: "@artifact/apps/base/home-system/bazarr/app/"
+    - name: blackbox-exporter
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/observability/blackbox-exporter/app/"
+          to: "@artifact/apps/base/observability/blackbox-exporter/app/"
+    - name: cert-manager
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/network-system/cert-manager/app/"
+          to: "@artifact/apps/base/network-system/cert-manager/app/"
+    - name: cilium
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/kube-system/cilium/app/"
+          to: "@artifact/apps/base/kube-system/cilium/app/"
+    - name: cloudflare-tunnel
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/network-system/cloudflare-tunnel/app/"
+          to: "@artifact/apps/base/network-system/cloudflare-tunnel/app/"
+    - name: cmangos-registration
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/game-servers/cmangos-registration/app/"
+          to: "@artifact/apps/base/game-servers/cmangos-registration/app/"
+    - name: cmangos
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/game-servers/cmangos/app/"
+          to: "@artifact/apps/base/game-servers/cmangos/app/"
+    - name: crossplane-providers
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/crossplane-system/crossplane/providers/"
+          to: "@artifact/apps/base/crossplane-system/crossplane/providers/"
+    - name: crossplane
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/crossplane-system/crossplane/app/"
+          to: "@artifact/apps/base/crossplane-system/crossplane/app/"
+    - name: crowdsec
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/security-system/crowdsec/app/"
+          to: "@artifact/apps/base/security-system/crowdsec/app/"
+    - name: democratic-csi
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/democratic-csi/democratic-csi/app/"
+          to: "@artifact/apps/base/democratic-csi/democratic-csi/app/"
+    - name: descheduler
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/kube-system/descheduler/app/"
+          to: "@artifact/apps/base/kube-system/descheduler/app/"
+    - name: dex-k8s-authenticator
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/network-system/dex-k8s-authenticator/app/"
+          to: "@artifact/apps/base/network-system/dex-k8s-authenticator/app/"
+    - name: dex
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/network-system/dex/app/"
+          to: "@artifact/apps/base/network-system/dex/app/"
+    - name: echo-server
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/network-system/echo-server/app/"
+          to: "@artifact/apps/base/network-system/echo-server/app/"
+    - name: emberstone-portal
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/game-servers/emberstone-portal/app/"
+          to: "@artifact/apps/base/game-servers/emberstone-portal/app/"
+    - name: enemy-territory
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/game-servers/enemy-territory/app/"
+          to: "@artifact/apps/base/game-servers/enemy-territory/app/"
+    - name: envoy-gateway
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/network-system/envoy-gateway/app/"
+          to: "@artifact/apps/base/network-system/envoy-gateway/app/"
+    - name: external-dns-unifi
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/network-system/external-dns-unifi/app/"
+          to: "@artifact/apps/base/network-system/external-dns-unifi/app/"
+    - name: external-dns
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/network-system/external-dns/app/"
+          to: "@artifact/apps/base/network-system/external-dns/app/"
+    - name: external-secrets
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/external-secrets/external-secrets/app/"
+          to: "@artifact/apps/base/external-secrets/external-secrets/app/"
+    - name: falco-exporter
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/security-system/falco-exporter/app/"
+          to: "@artifact/apps/base/security-system/falco-exporter/app/"
+    - name: falco
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/security-system/falco/app/"
+          to: "@artifact/apps/base/security-system/falco/app/"
+    - name: flux-instance-extras
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/flux-system/flux-instance/extras/"
+          to: "@artifact/apps/base/flux-system/flux-instance/extras/"
+    - name: gatekeeper
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/security-system/gatekeeper/app/"
+          to: "@artifact/apps/base/security-system/gatekeeper/app/"
+    - name: gha-runner-scale-set-controller
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/actions-runner-system/gha-runner-scale-set-controller/app/"
+          to: "@artifact/apps/base/actions-runner-system/gha-runner-scale-set-controller/app/"
+    - name: grafana-instance
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/observability/grafana/instance/"
+          to: "@artifact/apps/base/observability/grafana/instance/"
+    - name: grafana
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/observability/grafana/app/"
+          to: "@artifact/apps/base/observability/grafana/app/"
+    - name: harbor
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/harbor/harbor/app/"
+          to: "@artifact/apps/base/harbor/harbor/app/"
+    - name: home-assistant
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/home-system/home-assistant/app/"
+          to: "@artifact/apps/base/home-system/home-assistant/app/"
+    - name: jellyseerr
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/home-system/jellyseerr/app/"
+          to: "@artifact/apps/base/home-system/jellyseerr/app/"
+    - name: kagent-crds
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/ai-system/kagent/crds/"
+          to: "@artifact/apps/base/ai-system/kagent/crds/"
+    - name: kagent
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/ai-system/kagent/app/"
+          to: "@artifact/apps/base/ai-system/kagent/app/"
+    - name: keda
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/kube-system/keda/app/"
+          to: "@artifact/apps/base/kube-system/keda/app/"
+    - name: kgateway-crds
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/ai-system/kgateway/crds/"
+          to: "@artifact/apps/base/ai-system/kgateway/crds/"
+    - name: kgateway
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/ai-system/kgateway/app/"
+          to: "@artifact/apps/base/ai-system/kgateway/app/"
+    - name: kguardian
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/kguardian/kguardian/app/"
+          to: "@artifact/apps/base/kguardian/kguardian/app/"
+    - name: kmcp-crds
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/ai-system/kmcp/crds/"
+          to: "@artifact/apps/base/ai-system/kmcp/crds/"
+    - name: kmcp
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/ai-system/kmcp/app/"
+          to: "@artifact/apps/base/ai-system/kmcp/app/"
+    - name: kopia
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/volsync-system/kopia/app/"
+          to: "@artifact/apps/base/volsync-system/kopia/app/"
+    - name: kromgo
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/observability/kromgo/app/"
+          to: "@artifact/apps/base/observability/kromgo/app/"
+    - name: kube-prometheus-stack
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/observability/kube-prometheus-stack/app/"
+          to: "@artifact/apps/base/observability/kube-prometheus-stack/app/"
+    - name: kubelet-csr-approver
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/kube-system/kubelet-csr-approver/app/"
+          to: "@artifact/apps/base/kube-system/kubelet-csr-approver/app/"
+    - name: kyverno
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/security-system/kyverno/app/"
+          to: "@artifact/apps/base/security-system/kyverno/app/"
+    - name: loki
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/observability/loki/app/"
+          to: "@artifact/apps/base/observability/loki/app/"
+    - name: metrics-server
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/kube-system/metrics-server/app/"
+          to: "@artifact/apps/base/kube-system/metrics-server/app/"
+    - name: minecraft-bedrock-broadcaster
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/game-servers/minecraft-bedrock-broadcaster/app/"
+          to: "@artifact/apps/base/game-servers/minecraft-bedrock-broadcaster/app/"
+    - name: minecraft-bedrock
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/game-servers/minecraft-bedrock/app/"
+          to: "@artifact/apps/base/game-servers/minecraft-bedrock/app/"
+    - name: minecraft-pixelmon
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/game-servers/minecraft-pixelmon/app/"
+          to: "@artifact/apps/base/game-servers/minecraft-pixelmon/app/"
+    - name: minecraft-proxy
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/game-servers/minecraft-proxy/app/"
+          to: "@artifact/apps/base/game-servers/minecraft-proxy/app/"
+    - name: minecraft-rcon-web
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/game-servers/minecraft-rcon-web/app/"
+          to: "@artifact/apps/base/game-servers/minecraft-rcon-web/app/"
+    - name: minecraft-router
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/game-servers/minecraft-router/app/"
+          to: "@artifact/apps/base/game-servers/minecraft-router/app/"
+    - name: minecraft-witherstorm
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/game-servers/minecraft-witherstorm/app/"
+          to: "@artifact/apps/base/game-servers/minecraft-witherstorm/app/"
+    - name: minecraft
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/game-servers/minecraft/app/"
+          to: "@artifact/apps/base/game-servers/minecraft/app/"
+    - name: mosquitto
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/home-system/mosquitto/app/"
+          to: "@artifact/apps/base/home-system/mosquitto/app/"
+    - name: multus-networks
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/network-system/multus/networks/"
+          to: "@artifact/apps/base/network-system/multus/networks/"
+    - name: multus
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/network-system/multus/app/"
+          to: "@artifact/apps/base/network-system/multus/app/"
+    - name: n8n
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/ai-system/n8n/app/"
+          to: "@artifact/apps/base/ai-system/n8n/app/"
+    - name: nginx-ingress
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/nginx-ingress/nginx-ingress/app/"
+          to: "@artifact/apps/base/nginx-ingress/nginx-ingress/app/"
+    - name: oauth2-proxy
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/network-system/oauth2-proxy/app/"
+          to: "@artifact/apps/base/network-system/oauth2-proxy/app/"
+    - name: ollama
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/ai-system/ollama/app/"
+          to: "@artifact/apps/base/ai-system/ollama/app/"
+    - name: onepassword
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/external-secrets/onepassword/app/"
+          to: "@artifact/apps/base/external-secrets/onepassword/app/"
+    - name: open-feature-operator
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/development/open-feature-operator/app/"
+          to: "@artifact/apps/base/development/open-feature-operator/app/"
+    - name: open-webui
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/ai-system/open-webui/app/"
+          to: "@artifact/apps/base/ai-system/open-webui/app/"
+    - name: openclaw
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/ai-system/openclaw/app/"
+          to: "@artifact/apps/base/ai-system/openclaw/app/"
+    - name: otel
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/observability/otel/app/"
+          to: "@artifact/apps/base/observability/otel/app/"
+    - name: prowlarr
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/home-system/prowlarr/app/"
+          to: "@artifact/apps/base/home-system/prowlarr/app/"
+    - name: qbittorrent
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/home-system/qbittorrent/app/"
+          to: "@artifact/apps/base/home-system/qbittorrent/app/"
+    - name: qui
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/home-system/qui/app/"
+          to: "@artifact/apps/base/home-system/qui/app/"
+    - name: radarr
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/home-system/radarr/app/"
+          to: "@artifact/apps/base/home-system/radarr/app/"
+    - name: recyclarr
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/home-system/recyclarr/app/"
+          to: "@artifact/apps/base/home-system/recyclarr/app/"
+    - name: reflector
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/kube-system/reflector/app/"
+          to: "@artifact/apps/base/kube-system/reflector/app/"
+    - name: rook-ceph-cluster
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/rook-ceph/rook-ceph/cluster/"
+          to: "@artifact/apps/base/rook-ceph/rook-ceph/cluster/"
+    - name: rook-ceph
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/rook-ceph/rook-ceph/app/"
+          to: "@artifact/apps/base/rook-ceph/rook-ceph/app/"
+    - name: sabnzbd
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/home-system/sabnzbd/app/"
+          to: "@artifact/apps/base/home-system/sabnzbd/app/"
+    - name: silence-operator
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/observability/silence-operator/app/"
+          to: "@artifact/apps/base/observability/silence-operator/app/"
+    - name: smtp-relay
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/home-system/smtp-relay/app/"
+          to: "@artifact/apps/base/home-system/smtp-relay/app/"
+    - name: snapshot-controller
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/kube-system/snapshot-controller/app/"
+          to: "@artifact/apps/base/kube-system/snapshot-controller/app/"
+    - name: sonarr
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/home-system/sonarr/app/"
+          to: "@artifact/apps/base/home-system/sonarr/app/"
+    - name: spegel
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/kube-system/spegel/app/"
+          to: "@artifact/apps/base/kube-system/spegel/app/"
+    - name: tautulli
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/home-system/tautulli/app/"
+          to: "@artifact/apps/base/home-system/tautulli/app/"
+    - name: tetragon
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/kube-system/tetragon/app/"
+          to: "@artifact/apps/base/kube-system/tetragon/app/"
+    - name: vcluster
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/development/vcluster/app/"
+          to: "@artifact/apps/base/development/vcluster/app/"
+    - name: volsync-maintenance
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/volsync-system/volsync/maintenance/"
+          to: "@artifact/apps/base/volsync-system/volsync/maintenance/"
+    - name: volsync
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/volsync-system/volsync/app/"
+          to: "@artifact/apps/base/volsync-system/volsync/app/"
+    - name: vpa
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/observability/vpa/app/"
+          to: "@artifact/apps/base/observability/vpa/app/"
+    - name: zigbee2mqtt
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/home-system/zigbee2mqtt/app/"
+          to: "@artifact/apps/base/home-system/zigbee2mqtt/app/"

--- a/kubernetes/apps/base/flux-system/artifact-generator/kustomization.yaml
+++ b/kubernetes/apps/base/flux-system/artifact-generator/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - artifactgenerator.yaml

--- a/kubernetes/apps/base/flux-system/flux-instance/ks.yaml
+++ b/kubernetes/apps/base/flux-system/flux-instance/ks.yaml
@@ -14,8 +14,8 @@ spec:
   path: ./apps/base/flux-system/flux-instance/extras
   prune: false
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: flux-instance-extras
     namespace: flux-system
   targetNamespace: flux-system
   timeout: 5m

--- a/kubernetes/apps/base/game-servers/azerothcore-registration/ks.yaml
+++ b/kubernetes/apps/base/game-servers/azerothcore-registration/ks.yaml
@@ -17,8 +17,8 @@ spec:
   prune: true
   wait: true
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: azerothcore-registration
     namespace: flux-system
   dependsOn:
     - name: azerothcore

--- a/kubernetes/apps/base/game-servers/azerothcore/ks.yaml
+++ b/kubernetes/apps/base/game-servers/azerothcore/ks.yaml
@@ -17,8 +17,8 @@ spec:
   prune: true
   wait: true
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: azerothcore
     namespace: flux-system
   dependsOn:
     - name: onepassword

--- a/kubernetes/apps/base/game-servers/cmangos-registration/ks.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-registration/ks.yaml
@@ -17,8 +17,8 @@ spec:
   prune: true
   wait: true
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: cmangos-registration
     namespace: flux-system
   dependsOn:
     - name: cmangos

--- a/kubernetes/apps/base/game-servers/cmangos/ks.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos/ks.yaml
@@ -17,8 +17,8 @@ spec:
   prune: true
   wait: true
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: cmangos
     namespace: flux-system
   dependsOn:
     - name: onepassword

--- a/kubernetes/apps/base/game-servers/emberstone-portal/ks.yaml
+++ b/kubernetes/apps/base/game-servers/emberstone-portal/ks.yaml
@@ -17,8 +17,8 @@ spec:
   prune: true
   wait: true
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: emberstone-portal
     namespace: flux-system
   dependsOn:
     - name: cmangos

--- a/kubernetes/apps/base/game-servers/enemy-territory/ks.yaml
+++ b/kubernetes/apps/base/game-servers/enemy-territory/ks.yaml
@@ -13,6 +13,6 @@ spec:
       namespace: rook-ceph
   targetNamespace: game-servers
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: enemy-territory
     namespace: flux-system

--- a/kubernetes/apps/base/game-servers/minecraft-bedrock-broadcaster/ks.yaml
+++ b/kubernetes/apps/base/game-servers/minecraft-bedrock-broadcaster/ks.yaml
@@ -19,6 +19,6 @@ spec:
   wait: true
   targetNamespace: game-servers
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: minecraft-bedrock-broadcaster
     namespace: flux-system

--- a/kubernetes/apps/base/game-servers/minecraft-bedrock/ks.yaml
+++ b/kubernetes/apps/base/game-servers/minecraft-bedrock/ks.yaml
@@ -19,6 +19,6 @@ spec:
   wait: true
   targetNamespace: game-servers
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: minecraft-bedrock
     namespace: flux-system

--- a/kubernetes/apps/base/game-servers/minecraft-pixelmon/ks.yaml
+++ b/kubernetes/apps/base/game-servers/minecraft-pixelmon/ks.yaml
@@ -15,6 +15,6 @@ spec:
   wait: true
   targetNamespace: game-servers
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: minecraft-pixelmon
     namespace: flux-system

--- a/kubernetes/apps/base/game-servers/minecraft-proxy/ks.yaml
+++ b/kubernetes/apps/base/game-servers/minecraft-proxy/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: game-servers
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: minecraft-proxy
     namespace: flux-system

--- a/kubernetes/apps/base/game-servers/minecraft-rcon-web/ks.yaml
+++ b/kubernetes/apps/base/game-servers/minecraft-rcon-web/ks.yaml
@@ -13,6 +13,6 @@ spec:
   wait: true
   targetNamespace: game-servers
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: minecraft-rcon-web
     namespace: flux-system

--- a/kubernetes/apps/base/game-servers/minecraft-router/ks.yaml
+++ b/kubernetes/apps/base/game-servers/minecraft-router/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: game-servers
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: minecraft-router
     namespace: flux-system

--- a/kubernetes/apps/base/game-servers/minecraft-witherstorm/ks.yaml
+++ b/kubernetes/apps/base/game-servers/minecraft-witherstorm/ks.yaml
@@ -13,6 +13,6 @@ spec:
   wait: true
   targetNamespace: game-servers
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: minecraft-witherstorm
     namespace: flux-system

--- a/kubernetes/apps/base/game-servers/minecraft/ks.yaml
+++ b/kubernetes/apps/base/game-servers/minecraft/ks.yaml
@@ -19,6 +19,6 @@ spec:
   wait: true
   targetNamespace: game-servers
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: minecraft
     namespace: flux-system

--- a/kubernetes/apps/base/harbor/harbor/ks.yaml
+++ b/kubernetes/apps/base/harbor/harbor/ks.yaml
@@ -17,6 +17,6 @@ spec:
       namespace: volsync-system
   targetNamespace: harbor
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: harbor
     namespace: flux-system

--- a/kubernetes/apps/base/home-system/autobrr/ks.yaml
+++ b/kubernetes/apps/base/home-system/autobrr/ks.yaml
@@ -19,6 +19,6 @@ spec:
       namespace: volsync-system
   targetNamespace: home-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: autobrr
     namespace: flux-system

--- a/kubernetes/apps/base/home-system/bazarr/ks.yaml
+++ b/kubernetes/apps/base/home-system/bazarr/ks.yaml
@@ -17,6 +17,6 @@ spec:
       namespace: volsync-system
   targetNamespace: home-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: bazarr
     namespace: flux-system

--- a/kubernetes/apps/base/home-system/home-assistant/ks.yaml
+++ b/kubernetes/apps/base/home-system/home-assistant/ks.yaml
@@ -19,6 +19,6 @@ spec:
       namespace: volsync-system
   targetNamespace: home-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: home-assistant
     namespace: flux-system

--- a/kubernetes/apps/base/home-system/jellyseerr/ks.yaml
+++ b/kubernetes/apps/base/home-system/jellyseerr/ks.yaml
@@ -19,6 +19,6 @@ spec:
       namespace: volsync-system
   targetNamespace: home-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: jellyseerr
     namespace: flux-system

--- a/kubernetes/apps/base/home-system/mosquitto/ks.yaml
+++ b/kubernetes/apps/base/home-system/mosquitto/ks.yaml
@@ -19,6 +19,6 @@ spec:
       namespace: volsync-system
   targetNamespace: home-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: mosquitto
     namespace: flux-system

--- a/kubernetes/apps/base/home-system/prowlarr/ks.yaml
+++ b/kubernetes/apps/base/home-system/prowlarr/ks.yaml
@@ -19,6 +19,6 @@ spec:
       namespace: volsync-system
   targetNamespace: home-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: prowlarr
     namespace: flux-system

--- a/kubernetes/apps/base/home-system/qbittorrent/ks.yaml
+++ b/kubernetes/apps/base/home-system/qbittorrent/ks.yaml
@@ -19,6 +19,6 @@ spec:
       namespace: volsync-system
   targetNamespace: home-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: qbittorrent
     namespace: flux-system

--- a/kubernetes/apps/base/home-system/qui/ks.yaml
+++ b/kubernetes/apps/base/home-system/qui/ks.yaml
@@ -17,6 +17,6 @@ spec:
       namespace: volsync-system
   targetNamespace: home-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: qui
     namespace: flux-system

--- a/kubernetes/apps/base/home-system/radarr/ks.yaml
+++ b/kubernetes/apps/base/home-system/radarr/ks.yaml
@@ -19,6 +19,6 @@ spec:
       namespace: volsync-system
   targetNamespace: home-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: radarr
     namespace: flux-system

--- a/kubernetes/apps/base/home-system/recyclarr/ks.yaml
+++ b/kubernetes/apps/base/home-system/recyclarr/ks.yaml
@@ -19,6 +19,6 @@ spec:
       namespace: volsync-system
   targetNamespace: home-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: recyclarr
     namespace: flux-system

--- a/kubernetes/apps/base/home-system/sabnzbd/ks.yaml
+++ b/kubernetes/apps/base/home-system/sabnzbd/ks.yaml
@@ -19,6 +19,6 @@ spec:
       namespace: volsync-system
   targetNamespace: home-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: sabnzbd
     namespace: flux-system

--- a/kubernetes/apps/base/home-system/smtp-relay/ks.yaml
+++ b/kubernetes/apps/base/home-system/smtp-relay/ks.yaml
@@ -13,6 +13,6 @@ spec:
       namespace: external-secrets
   targetNamespace: home-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: smtp-relay
     namespace: flux-system

--- a/kubernetes/apps/base/home-system/sonarr/ks.yaml
+++ b/kubernetes/apps/base/home-system/sonarr/ks.yaml
@@ -19,6 +19,6 @@ spec:
       namespace: volsync-system
   targetNamespace: home-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: sonarr
     namespace: flux-system

--- a/kubernetes/apps/base/home-system/tautulli/ks.yaml
+++ b/kubernetes/apps/base/home-system/tautulli/ks.yaml
@@ -19,6 +19,6 @@ spec:
       namespace: volsync-system
   targetNamespace: home-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: tautulli
     namespace: flux-system

--- a/kubernetes/apps/base/home-system/zigbee2mqtt/ks.yaml
+++ b/kubernetes/apps/base/home-system/zigbee2mqtt/ks.yaml
@@ -21,6 +21,6 @@ spec:
       namespace: volsync-system
   targetNamespace: home-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: zigbee2mqtt
     namespace: flux-system

--- a/kubernetes/apps/base/kguardian/kguardian/ks.yaml
+++ b/kubernetes/apps/base/kguardian/kguardian/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: kguardian
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: kguardian
     namespace: flux-system

--- a/kubernetes/apps/base/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/base/kube-system/cilium/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: false
   targetNamespace: kube-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: cilium
     namespace: flux-system

--- a/kubernetes/apps/base/kube-system/descheduler/ks.yaml
+++ b/kubernetes/apps/base/kube-system/descheduler/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: kube-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: descheduler
     namespace: flux-system

--- a/kubernetes/apps/base/kube-system/keda/ks.yaml
+++ b/kubernetes/apps/base/kube-system/keda/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: kube-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: keda
     namespace: flux-system

--- a/kubernetes/apps/base/kube-system/kubelet-csr-approver/ks.yaml
+++ b/kubernetes/apps/base/kube-system/kubelet-csr-approver/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: kube-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: kubelet-csr-approver
     namespace: flux-system

--- a/kubernetes/apps/base/kube-system/metrics-server/ks.yaml
+++ b/kubernetes/apps/base/kube-system/metrics-server/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: kube-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: metrics-server
     namespace: flux-system

--- a/kubernetes/apps/base/kube-system/reflector/ks.yaml
+++ b/kubernetes/apps/base/kube-system/reflector/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: kube-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: reflector
     namespace: flux-system

--- a/kubernetes/apps/base/kube-system/snapshot-controller/ks.yaml
+++ b/kubernetes/apps/base/kube-system/snapshot-controller/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: kube-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: snapshot-controller
     namespace: flux-system

--- a/kubernetes/apps/base/kube-system/spegel/ks.yaml
+++ b/kubernetes/apps/base/kube-system/spegel/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: kube-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: spegel
     namespace: flux-system

--- a/kubernetes/apps/base/kube-system/tetragon/ks.yaml
+++ b/kubernetes/apps/base/kube-system/tetragon/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: kube-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: tetragon
     namespace: flux-system

--- a/kubernetes/apps/base/network-system/cert-manager/ks.yaml
+++ b/kubernetes/apps/base/network-system/cert-manager/ks.yaml
@@ -26,6 +26,6 @@ spec:
   wait: false
   targetNamespace: network-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: cert-manager
     namespace: flux-system

--- a/kubernetes/apps/base/network-system/cloudflare-tunnel/ks.yaml
+++ b/kubernetes/apps/base/network-system/cloudflare-tunnel/ks.yaml
@@ -15,6 +15,6 @@ spec:
       namespace: external-secrets
   targetNamespace: network-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: cloudflare-tunnel
     namespace: flux-system

--- a/kubernetes/apps/base/network-system/dex-k8s-authenticator/ks.yaml
+++ b/kubernetes/apps/base/network-system/dex-k8s-authenticator/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: network-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: dex-k8s-authenticator
     namespace: flux-system

--- a/kubernetes/apps/base/network-system/dex/ks.yaml
+++ b/kubernetes/apps/base/network-system/dex/ks.yaml
@@ -15,6 +15,6 @@ spec:
       namespace: network-system
   targetNamespace: network-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: dex
     namespace: flux-system

--- a/kubernetes/apps/base/network-system/echo-server/ks.yaml
+++ b/kubernetes/apps/base/network-system/echo-server/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: network-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: echo-server
     namespace: flux-system

--- a/kubernetes/apps/base/network-system/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/base/network-system/envoy-gateway/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: network-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: envoy-gateway
     namespace: flux-system

--- a/kubernetes/apps/base/network-system/external-dns-unifi/ks.yaml
+++ b/kubernetes/apps/base/network-system/external-dns-unifi/ks.yaml
@@ -15,6 +15,6 @@ spec:
   wait: true
   targetNamespace: network-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: external-dns-unifi
     namespace: flux-system

--- a/kubernetes/apps/base/network-system/external-dns/ks.yaml
+++ b/kubernetes/apps/base/network-system/external-dns/ks.yaml
@@ -13,6 +13,6 @@ spec:
   wait: true
   targetNamespace: network-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: external-dns
     namespace: flux-system

--- a/kubernetes/apps/base/network-system/multus/ks.yaml
+++ b/kubernetes/apps/base/network-system/multus/ks.yaml
@@ -10,8 +10,8 @@ spec:
   wait: true
   targetNamespace: network-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: multus
     namespace: flux-system
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
@@ -28,6 +28,6 @@ spec:
       namespace: network-system
   targetNamespace: network-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: multus-networks
     namespace: flux-system

--- a/kubernetes/apps/base/network-system/oauth2-proxy/ks.yaml
+++ b/kubernetes/apps/base/network-system/oauth2-proxy/ks.yaml
@@ -13,6 +13,6 @@ spec:
   wait: true
   targetNamespace: network-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: oauth2-proxy
     namespace: flux-system

--- a/kubernetes/apps/base/nginx-ingress/nginx-ingress/ks.yaml
+++ b/kubernetes/apps/base/nginx-ingress/nginx-ingress/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: nginx-ingress
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: nginx-ingress
     namespace: flux-system

--- a/kubernetes/apps/base/observability/blackbox-exporter/ks.yaml
+++ b/kubernetes/apps/base/observability/blackbox-exporter/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: observability
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: blackbox-exporter
     namespace: flux-system

--- a/kubernetes/apps/base/observability/grafana/ks.yaml
+++ b/kubernetes/apps/base/observability/grafana/ks.yaml
@@ -13,8 +13,8 @@ spec:
       namespace: network-system
   targetNamespace: observability
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: grafana
     namespace: flux-system
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
@@ -37,6 +37,6 @@ spec:
       namespace: volsync-system
   targetNamespace: observability
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: grafana-instance
     namespace: flux-system

--- a/kubernetes/apps/base/observability/kromgo/ks.yaml
+++ b/kubernetes/apps/base/observability/kromgo/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: observability
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: kromgo
     namespace: flux-system

--- a/kubernetes/apps/base/observability/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/ks.yaml
@@ -17,6 +17,6 @@ spec:
       namespace: volsync-system
   targetNamespace: observability
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: kube-prometheus-stack
     namespace: flux-system

--- a/kubernetes/apps/base/observability/loki/ks.yaml
+++ b/kubernetes/apps/base/observability/loki/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: false
   targetNamespace: observability
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: loki
     namespace: flux-system

--- a/kubernetes/apps/base/observability/otel/ks.yaml
+++ b/kubernetes/apps/base/observability/otel/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: false
   targetNamespace: observability
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: otel
     namespace: flux-system

--- a/kubernetes/apps/base/observability/silence-operator/ks.yaml
+++ b/kubernetes/apps/base/observability/silence-operator/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: observability
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: silence-operator
     namespace: flux-system

--- a/kubernetes/apps/base/observability/vpa/ks.yaml
+++ b/kubernetes/apps/base/observability/vpa/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: false
   targetNamespace: observability
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: vpa
     namespace: flux-system

--- a/kubernetes/apps/base/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph/ks.yaml
@@ -13,8 +13,8 @@ spec:
       namespace: kube-system
   targetNamespace: rook-ceph
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: rook-ceph
     namespace: flux-system
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
@@ -34,6 +34,6 @@ spec:
   #   namespace: volsync-system
 
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: rook-ceph-cluster
     namespace: flux-system

--- a/kubernetes/apps/base/security-system/crowdsec/ks.yaml
+++ b/kubernetes/apps/base/security-system/crowdsec/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: security-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: crowdsec
     namespace: flux-system

--- a/kubernetes/apps/base/security-system/falco-exporter/ks.yaml
+++ b/kubernetes/apps/base/security-system/falco-exporter/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: security-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: falco-exporter
     namespace: flux-system

--- a/kubernetes/apps/base/security-system/falco/ks.yaml
+++ b/kubernetes/apps/base/security-system/falco/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: security-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: falco
     namespace: flux-system

--- a/kubernetes/apps/base/security-system/gatekeeper/ks.yaml
+++ b/kubernetes/apps/base/security-system/gatekeeper/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: security-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: gatekeeper
     namespace: flux-system

--- a/kubernetes/apps/base/security-system/kyverno/ks.yaml
+++ b/kubernetes/apps/base/security-system/kyverno/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: security-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: kyverno
     namespace: flux-system

--- a/kubernetes/apps/base/volsync-system/kopia/ks.yaml
+++ b/kubernetes/apps/base/volsync-system/kopia/ks.yaml
@@ -10,6 +10,6 @@ spec:
   wait: true
   targetNamespace: volsync-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: kopia
     namespace: flux-system

--- a/kubernetes/apps/base/volsync-system/volsync/ks.yaml
+++ b/kubernetes/apps/base/volsync-system/volsync/ks.yaml
@@ -10,8 +10,8 @@ spec:
   wait: true
   targetNamespace: volsync-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: volsync
     namespace: flux-system
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
@@ -28,6 +28,6 @@ spec:
     - name: volsync
       namespace: volsync-system
   sourceRef:
-    kind: OCIRepository
-    name: flux-system
+    kind: ExternalArtifact
+    name: volsync-maintenance
     namespace: flux-system

--- a/kubernetes/apps/overlays/cluster-00/kustomization.yaml
+++ b/kubernetes/apps/overlays/cluster-00/kustomization.yaml
@@ -36,6 +36,7 @@ resources:
   - ../../base/development/open-feature-operator/ks.yaml
   - ../../base/external-secrets/external-secrets/ks.yaml
   - ../../base/external-secrets/onepassword/ks.yaml
+  - ../../base/flux-system/artifact-generator
   - ../../base/flux-system/flux-instance/ks.yaml
   - ../../base/flux-system/repositories
   - ../../base/harbor/harbor/ks.yaml


### PR DESCRIPTION
## Summary

Introduces Flux ArtifactGenerator to eliminate unnecessary reconciliation in this monorepo.

**Problem:** Every push to main produces a new OCI artifact digest (because `flux push artifact --revision` embeds the git SHA). This triggers **all ~93 child Kustomizations** to reconcile, even when only one app changed. Each reconciliation involves downloading the artifact, running `kustomize build`, and doing a server-side apply dry-run against the API server.

**Solution:** The [ArtifactGenerator API](https://fluxcd.io/flux/components/source/artifactgenerators/) (Flux v2.7+, powered by `source-watcher` which is already enabled) decomposes the single OCIRepository into per-app ExternalArtifacts using **content-based SHA256 hashing**. When the OCI source changes, source-watcher re-evaluates each artifact. Only artifacts whose file content actually changed get new revisions -- the rest stay stable and their downstream Kustomizations skip reconciliation entirely.

### Changes

- **New:** `kubernetes/apps/base/flux-system/artifact-generator/artifactgenerator.yaml` -- ArtifactGenerator with 93 per-app artifacts, each mapping a Kustomization name to its app directory path
- **Modified:** All 84 `ks.yaml` files -- `sourceRef` changed from `OCIRepository: flux-system` to `ExternalArtifact: {kustomization-name}`
- **Modified:** `kubernetes/apps/overlays/cluster-00/kustomization.yaml` -- includes the artifact-generator resource

### Design decisions

- **Root cluster Kustomization stays on OCIRepository** -- it only generates lightweight Namespace + Kustomization CRDs, so reconciling it on every push is cheap
- **Path structure preserved in artifacts** -- each ExternalArtifact mirrors the original directory structure (`@repo/apps/base/.../app/` → `@artifact/apps/base/.../app/`), so `spec.path` fields in ks.yaml files don't change
- **All apps included** (active and disabled) -- disabled apps' ExternalArtifacts are harmless; they'll be ready when enabled
- **`originRevision: "@repo"`** on each artifact -- preserves OCI source revision in ExternalArtifact metadata for traceability without affecting content-based revision tracking

### Deployment note

On initial deployment, child Kustomizations will briefly fail to find their ExternalArtifact sources while the ArtifactGenerator creates them. The default `retryInterval: 1m` will self-heal within 1-2 minutes. No manual intervention required.

### How it works after deployment

```
git push → OCI artifact updated → OCIRepository detects new digest
  ├── Root Kustomization reconciles (cheap: re-applies child CRDs, no diff)
  └── ArtifactGenerator re-evaluates 93 artifacts
       ├── Changed app: new content hash → ExternalArtifact updated → child reconciles
       └── Unchanged apps: same content hash → ExternalArtifact stable → no reconciliation
```

## Test plan

- [ ] Verify ArtifactGenerator resource is valid (`kubectl apply --dry-run=client -f artifactgenerator.yaml`)
- [ ] Verify all ExternalArtifact names match Kustomization sourceRef names (automated in generation script)
- [ ] Verify no OCIRepository references remain in any `ks.yaml` under `apps/base/`
- [ ] After merge: confirm ExternalArtifacts are created in flux-system namespace
- [ ] After merge: confirm child Kustomizations successfully reconcile from ExternalArtifact sources
- [ ] After merge: push a change to a single app and verify only that app's Kustomization reconciles