### PR TITLE
feat(preview): PR preview environments for emberstone-portal

### DIFF
--- a/kubernetes/apps/base/flux-system/artifact-generator/artifactgenerator.yaml
+++ b/kubernetes/apps/base/flux-system/artifact-generator/artifactgenerator.yaml
@@ -365,6 +365,11 @@ spec:
       copy:
         - from: "@repo/apps/base/observability/otel/app/"
           to: "@artifact/apps/base/observability/otel/app/"
+    - name: preview-system
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/preview-system/app/"
+          to: "@artifact/apps/base/preview-system/app/"
     - name: prowlarr
       originRevision: "@repo"
       copy:

--- a/kubernetes/apps/base/network-system/envoy-gateway/app/certificates.yaml
+++ b/kubernetes/apps/base/network-system/envoy-gateway/app/certificates.yaml
@@ -26,3 +26,4 @@ spec:
   dnsNames:
     - ${CLUSTER_DOMAIN}
     - '*.${CLUSTER_DOMAIN}'
+    - '*.preview.${CLUSTER_DOMAIN}'

--- a/kubernetes/apps/base/preview-system/app/externalsecret.yaml
+++ b/kubernetes/apps/base/preview-system/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-auth
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: github-auth
+    template:
+      data:
+        username: xunholy
+        password: "{{ .FLUX_GITHUB_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: flux

--- a/kubernetes/apps/base/preview-system/app/kustomization.yaml
+++ b/kubernetes/apps/base/preview-system/app/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 
 resources:
   - externalsecret.yaml
+  - notification.yaml
   - resourcesetinputprovider.yaml
   - resourceset.yaml

--- a/kubernetes/apps/base/preview-system/app/kustomization.yaml
+++ b/kubernetes/apps/base/preview-system/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - externalsecret.yaml
+  - resourcesetinputprovider.yaml
+  - resourceset.yaml

--- a/kubernetes/apps/base/preview-system/app/notification.yaml
+++ b/kubernetes/apps/base/preview-system/app/notification.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: github-pr-comment
+spec:
+  type: githubdispatch
+  address: https://github.com/xunholy/k8s-gitops
+  secretRef:
+    name: github-auth
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: preview-status
+spec:
+  providerRef:
+    name: github-pr-comment
+  eventSeverity: info
+  eventSources:
+    - kind: Kustomization
+      name: "*"
+      namespace: preview-pr-*
+    - kind: HelmRelease
+      name: "*"
+      namespace: preview-pr-*

--- a/kubernetes/apps/base/preview-system/app/resourceset.yaml
+++ b/kubernetes/apps/base/preview-system/app/resourceset.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSet
+metadata:
+  name: emberstone-portal-preview
+spec:
+  inputsFrom:
+    - kind: ResourceSetInputProvider
+      name: github-pr-previews
+  resources:
+    # Namespace per PR
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: preview-pr-<< inputs.id >>
+        labels:
+          pod-security.kubernetes.io/enforce: baseline
+          preview: "true"
+        annotations:
+          preview.fluxcd.io/pr: << inputs.id | quote >>
+          preview.fluxcd.io/branch: << inputs.branch | quote >>
+          preview.fluxcd.io/author: << inputs.author | quote >>
+    # ResourceQuota to limit preview resource usage
+    - apiVersion: v1
+      kind: ResourceQuota
+      metadata:
+        name: preview-quota
+        namespace: preview-pr-<< inputs.id >>
+      spec:
+        hard:
+          requests.cpu: "500m"
+          requests.memory: "512Mi"
+          limits.cpu: "1"
+          limits.memory: "1Gi"
+          pods: "10"
+    # Git source at the PR commit SHA
+    - apiVersion: source.toolkit.fluxcd.io/v1
+      kind: GitRepository
+      metadata:
+        name: pr-<< inputs.id >>
+        namespace: preview-pr-<< inputs.id >>
+      spec:
+        interval: 5m
+        url: https://github.com/xunholy/k8s-gitops
+        ref:
+          commit: << inputs.sha >>
+        secretRef:
+          name: github-auth
+    # Copy the GitHub auth secret into the preview namespace
+    - apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      metadata:
+        name: github-auth
+        namespace: preview-pr-<< inputs.id >>
+      spec:
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: onepassword
+        target:
+          name: github-auth
+          template:
+            data:
+              username: xunholy
+              password: "{{ .FLUX_GITHUB_TOKEN }}"
+        dataFrom:
+          - extract:
+              key: flux
+    # Kustomization deploying emberstone-portal from the PR branch
+    - apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: emberstone-portal-pr-<< inputs.id >>
+        namespace: preview-pr-<< inputs.id >>
+        labels:
+          gitops.owncloud.ai/defaults: disabled
+        annotations:
+          event.toolkit.fluxcd.io/change_request: << inputs.id | quote >>
+          event.toolkit.fluxcd.io/commit: << inputs.sha | quote >>
+      spec:
+        interval: 5m
+        retryInterval: 1m
+        timeout: 10m
+        prune: true
+        wait: true
+        path: ./kubernetes/apps/base/game-servers/emberstone-portal/app
+        sourceRef:
+          kind: GitRepository
+          name: pr-<< inputs.id >>
+        targetNamespace: preview-pr-<< inputs.id >>
+        postBuild:
+          substitute:
+            CLUSTER_TIMEZONE: "Australia/Melbourne"
+            CLUSTER_DOMAIN: "owncloud.ai"
+    # HTTPRoute for preview access at preview-{pr-id}.emberstone.owncloud.ai
+    - apiVersion: gateway.networking.k8s.io/v1
+      kind: HTTPRoute
+      metadata:
+        name: emberstone-portal-preview
+        namespace: preview-pr-<< inputs.id >>
+        annotations:
+          external-dns.alpha.kubernetes.io/external: "true"
+      spec:
+        parentRefs:
+          - name: envoy-external
+            namespace: network-system
+            sectionName: https
+        hostnames:
+          - preview-pr-<< inputs.id >>.emberstone.owncloud.ai
+        rules:
+          - backendRefs:
+              - name: emberstone-portal
+                port: 80
+                weight: 100

--- a/kubernetes/apps/base/preview-system/app/resourceset.yaml
+++ b/kubernetes/apps/base/preview-system/app/resourceset.yaml
@@ -91,7 +91,7 @@ spec:
           substitute:
             CLUSTER_TIMEZONE: "Australia/Melbourne"
             CLUSTER_DOMAIN: "owncloud.ai"
-    # HTTPRoute for preview access at preview-{pr-id}.emberstone.owncloud.ai
+    # HTTPRoute for preview access at {id}.preview.owncloud.ai
     - apiVersion: gateway.networking.k8s.io/v1
       kind: HTTPRoute
       metadata:
@@ -105,7 +105,7 @@ spec:
             namespace: network-system
             sectionName: https
         hostnames:
-          - preview-pr-<< inputs.id >>.emberstone.owncloud.ai
+          - << inputs.id >>.preview.owncloud.ai
         rules:
           - backendRefs:
               - name: emberstone-portal

--- a/kubernetes/apps/base/preview-system/app/resourceset.yaml
+++ b/kubernetes/apps/base/preview-system/app/resourceset.yaml
@@ -91,17 +91,15 @@ spec:
           substitute:
             CLUSTER_TIMEZONE: "Australia/Melbourne"
             CLUSTER_DOMAIN: "owncloud.ai"
-    # HTTPRoute for preview access at {id}.preview.owncloud.ai
+    # HTTPRoute for internal-only preview access at {id}.preview.owncloud.ai
     - apiVersion: gateway.networking.k8s.io/v1
       kind: HTTPRoute
       metadata:
         name: emberstone-portal-preview
         namespace: preview-pr-<< inputs.id >>
-        annotations:
-          external-dns.alpha.kubernetes.io/external: "true"
       spec:
         parentRefs:
-          - name: envoy-external
+          - name: envoy-internal
             namespace: network-system
             sectionName: https
         hostnames:

--- a/kubernetes/apps/base/preview-system/app/resourcesetinputprovider.yaml
+++ b/kubernetes/apps/base/preview-system/app/resourcesetinputprovider.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSetInputProvider
+metadata:
+  name: github-pr-previews
+  annotations:
+    fluxcd.controlplane.io/reconcileEvery: "5m"
+spec:
+  type: GitHubPullRequest
+  url: https://github.com/xunholy/k8s-gitops
+  secretRef:
+    name: github-auth
+  filter:
+    labels:
+      - "deploy/preview"
+    limit: 3

--- a/kubernetes/apps/base/preview-system/ks.yaml
+++ b/kubernetes/apps/base/preview-system/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: preview-system
+  namespace: preview-system
+spec:
+  dependsOn:
+    - name: onepassword
+      namespace: external-secrets
+  path: "./apps/base/preview-system/app"
+  wait: true
+  targetNamespace: preview-system
+  sourceRef:
+    kind: ExternalArtifact
+    name: preview-system
+    namespace: flux-system

--- a/kubernetes/apps/base/preview-system/kustomization.yaml
+++ b/kubernetes/apps/base/preview-system/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: preview-system
+
+components:
+  - ../../../components/common
+
+resources:
+  - namespace.yaml

--- a/kubernetes/apps/base/preview-system/namespace.yaml
+++ b/kubernetes/apps/base/preview-system/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: preview-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: baseline

--- a/kubernetes/apps/overlays/cluster-00/kustomization.yaml
+++ b/kubernetes/apps/overlays/cluster-00/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ../../base/network-system
   - ../../base/nginx-ingress
   - ../../base/observability
+  - ../../base/preview-system
   - ../../base/rook-ceph
   - ../../base/security-system
   - ../../base/volsync-system
@@ -91,6 +92,7 @@ resources:
   # - ../../base/network-system/multus/ks.yaml
   - ../../base/network-system/oauth2-proxy/ks.yaml
   - ../../base/nginx-ingress/nginx-ingress/ks.yaml
+  - ../../base/preview-system/ks.yaml
   - ../../base/observability/blackbox-exporter/ks.yaml
   - ../../base/observability/grafana/ks.yaml
   # - ../../base/observability/jaeger/ks.yaml


### PR DESCRIPTION
## Summary

Adds ephemeral PR preview environments for the emberstone-portal using Flux Operator's ResourceSetInputProvider and ResourceSet APIs.

## How it works

1. Add the `deploy/preview` label to any PR
2. The ResourceSetInputProvider detects the labeled PR (polls every 5m)
3. The ResourceSet automatically creates per-PR resources:
   - `preview-pr-{id}` namespace with ResourceQuota (500m CPU / 1Gi memory)
   - GitRepository source at the PR's commit SHA
   - ExternalSecret for GitHub auth (via 1Password ClusterSecretStore)
   - Kustomization deploying emberstone-portal from the PR branch
   - HTTPRoute exposing the preview at `preview-pr-{id}.emberstone.owncloud.ai`
4. When the PR is updated (new commit), the preview re-reconciles automatically
5. When the PR is closed/merged, all preview resources are garbage collected

## Architecture

```
GitHub PR (labeled deploy/preview)
  → ResourceSetInputProvider (polls GitHub API)
    → ResourceSet (templates per-PR resources)
      → Namespace: preview-pr-{id}
      → GitRepository: repo @ PR commit SHA
      → Kustomization: emberstone-portal app
      → HTTPRoute: preview-pr-{id}.emberstone.owncloud.ai
```

## Safety guardrails

- **Max 3 concurrent previews** via `filter.limit: 3`
- **ResourceQuota per preview** limits CPU/memory/pod count
- **Label-gated** - only PRs with `deploy/preview` trigger deployment
- **Automatic cleanup** - ResourceSet GC deletes everything when PR closes
- **Baseline pod security** on preview namespace

## Files

| File | Purpose |
|------|---------|
| `preview-system/namespace.yaml` | Preview system namespace |
| `preview-system/kustomization.yaml` | System-level Kustomize config with common alerts |
| `preview-system/ks.yaml` | Flux Kustomization (depends on onepassword for ExternalSecret) |
| `preview-system/app/externalsecret.yaml` | GitHub auth token from 1Password |
| `preview-system/app/resourcesetinputprovider.yaml` | Watches GitHub PRs with `deploy/preview` label |
| `preview-system/app/resourceset.yaml` | Templates per-PR preview environments |
| `preview-system/app/kustomization.yaml` | Kustomize config for app resources |
| `artifact-generator/artifactgenerator.yaml` | Added preview-system ExternalArtifact |
| `overlays/cluster-00/kustomization.yaml` | Added preview-system to overlay |

## Test plan

- [ ] Verify YAML validity (pre-commit hooks passed)
- [ ] After merge: confirm preview-system namespace is created
- [ ] After merge: confirm ResourceSetInputProvider is Ready
- [ ] After merge: confirm ResourceSet is Ready (with 0 inputs initially)
- [ ] Create a test PR with `deploy/preview` label and verify preview deploys
- [ ] Verify preview is accessible at `preview-pr-{id}.emberstone.owncloud.ai`
- [ ] Close the test PR and verify all preview resources are cleaned up