### PR TITLE
Upgrade kustomize-mutating-webhook to 0.10.0

### DIFF
--- a/kubernetes/bootstrap/helmfile.yaml
+++ b/kubernetes/bootstrap/helmfile.yaml
@@ -37,7 +37,7 @@ releases:
   - name: kustomize-mutating-webhook
     namespace: flux-system
     chart: kustomize-mutating-webhook/kustomize-mutating-webhook
-    version: 0.9.0
+    version: 0.10.0
     wait: false
     values: ['{{ requiredEnv "ROOT_DIR" }}/kubernetes/clusters/{{ requiredEnv "CLUSTER_ID"}}/flux-system/kustomize-mutating-webhook/app/values.yaml']
     needs: ['network-system/cert-manager']

--- a/kubernetes/clusters/cluster-00/flux-system/kustomize-mutating-webhook/app/helmrelease.yaml
+++ b/kubernetes/clusters/cluster-00/flux-system/kustomize-mutating-webhook/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   interval: 5m
   chart:
     spec:
-      version: 0.9.0
+      version: 0.10.0
       chart: kustomize-mutating-webhook
       sourceRef:
         kind: HelmRepository

--- a/kubernetes/clusters/cluster-00/flux-system/kustomize-mutating-webhook/app/values.yaml
+++ b/kubernetes/clusters/cluster-00/flux-system/kustomize-mutating-webhook/app/values.yaml
@@ -1,7 +1,7 @@
 ---
 image:
   repository: ghcr.io/xunholy/kustomize-mutating-webhook
-replicaCount: 1
+replicas: 1
 certManager:
   enabled: true
 configMaps:
@@ -12,6 +12,8 @@ secrets:
     name: cluster-secrets
 env:
   LOG_LEVEL: debug
+  AUTO_UPDATE_KUSTOMIZATIONS: "true"
+  AUTO_UPDATE_EXCLUDE_NAMESPACES: "flux-system"
 podDisruptionBudget:
   enabled: false
 securityContext:


### PR DESCRIPTION
## Summary

- Upgrade kustomize-mutating-webhook chart from 0.9.0 to 0.10.0
- Update values to match new chart structure
- Update bootstrap helmfile version

## What's new in 0.10.0

- Config watching switched from filesystem (fsnotify) to Kubernetes API informers — changes detected instantly
- Auto-update triggers re-injection of config into all Kustomizations when ConfigMap/Secret data changes
- Namespace-scoped Role/RoleBinding for ConfigMap/Secret read access
- HTTP server timeouts, TLS 1.2 minimum, proper readiness probe
- Numerous bug fixes (shutdown races, JSON injection, error handling)
- DNS egress in NetworkPolicy for informer API calls

## Test plan

- [x] Tested on cluster-00 with PR image — informer synced 50 keys, 65 Kustomizations updated
- [x] Verified hot-reload: ConfigMap patch detected instantly, federated to all Kustomizations
- [x] Verified works with Flux controller network policies enabled
- [ ] Verify chart 0.10.0 is published and available in the Helm repository