### PR TITLE
chore(observability): extend NodeMemoryHighUtilization grace to 30m

### DIFF
--- a/kubernetes/apps/base/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -83,6 +83,10 @@ spec:
         for: 1h
       TargetDown:
         for: 15m
+      # 15m default fires on transient memory spikes (Kopia backups on TrueNAS,
+      # ZFS scrubs, batch I/O). Real pressure outlasts 30m; backups don't.
+      NodeMemoryHighUtilization:
+        for: 30m
     alertmanager:
       alertmanagerSpec:
         alertmanagerConfiguration:


### PR DESCRIPTION
## Summary
- Bump `NodeMemoryHighUtilization` `for:` from upstream default 15m → 30m via `defaultRules.customRules`
- Single 4-line addition; follows the same convention already used for `KubePodNotReady`, `KubePodCrashLooping`, `KubeContainerWaiting`, etc.

## Why
Investigated an alert firing on 2026-05-04 against `expanse.internal:9100` (the TrueNAS NAS, not a cluster node):

- Memory ramped from baseline → 92.03% over ~30 minutes
- Caused by a Kopia backup window (active sequential I/O, not ZFS ARC steady-state)
- Recovered on its own ~30 minutes later — no real pressure event, no leak, no action taken

The 15m default fires before backups finish. 30m filters out batch-I/O spikes (backups, ZFS scrubs, indexing) without losing the signal that matters: real leaks/runaways keep climbing past 30m and still page.

## Test plan
- [ ] Flux reconciles the HelmRelease cleanly
- [ ] `kubectl get prometheusrule -n observability -o yaml | grep -A3 NodeMemoryHighUtilization` shows `for: 30m`
- [ ] Next backup window does not fire the alert (within ~24h of merge)
- [ ] Real memory pressure (force-tested by stressing a node) still pages after the 30m window

## Related
Discovered while investigating the 2026-05-04 alert; full diagnosis: TrueNAS Kopia backup driving transient memory pressure, ZFS ARC reporting normal.