### PR TITLE
revert(cmangos): pin image to last known stable 88f46de6

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
@@ -76,7 +76,7 @@ spec:
           app:
             image:
               repository: ghcr.io/xunholy/cmangos-classic
-              tag: 2de514e3aa2ab2530d5ad1a750a460fbc3a2c335
+              tag: 88f46de6dda338ce51a7756e8fd4c704f580d2ae4e
             args: ["realmd"]
             env:
               TZ: ${CLUSTER_TIMEZONE}
@@ -133,7 +133,7 @@ spec:
           app:
             image:
               repository: ghcr.io/xunholy/cmangos-classic
-              tag: 2de514e3aa2ab2530d5ad1a750a460fbc3a2c335
+              tag: 88f46de6dda338ce51a7756e8fd4c704f580d2ae4e
             args: ["mangosd"]
             tty: true
             stdin: true


### PR DESCRIPTION
## Why

Production cmangos has been in CrashLoopBackOff since the image bump to `2de514e3` reconciled (~01:55Z today). Five SIGSEGV restarts so far; each container runs ~3.5–5 min before crashing. Real users disconnecting.

Image `88f46de6` ran cleanly for 12h+ before the bump.

## What this does

Pins both realmd and mangosd containers back to `88f46de6dda338ce51a7756e8fd4c704f580d2ae4e`. Single-file diff:

\`\`\`
kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml | 4 ++--
\`\`\`

## What was audited before reverting

- **Vendored playerbots tree** vs upstream `cmangos/playerbots@98487e010c`: byte-identical except for one local file (`UpdateGearAction.cpp`) carrying the documented EnchantItem `EquippedItemInventoryTypeMask` guard. Patch is a defensive `continue`, no memory hazards.
- **Build wiring**: FetchContent cleanly replaced by `add_subdirectory`; `target_link_libraries(... PUBLIC playerbots)` and `add_dependencies` intact; `.dockerignore` exclusion removed; `Dockerfile` COPY paths correct.
- **Runtime config**: `aiplayerbot.conf` composed by entrypoint, `AiPlayerbot.Enabled = 1`. `modules.conf` is now documentation-only (no build consumer).
- **`.gm` security migration** (ran 30 min before crashes started): ruled out by timeline — the prior pod ran the migrated DB cleanly for 37 minutes on the old image; the identical `lookup-gm-security` migration pattern ran 16h ago without incident.

Net: source-level diff between `88f46de6` and `2de514e3` is one defensive `continue`. The crash must be binary-level layout drift from the FetchContent → vendored build-system switch re-exposing latent UB in playerbots or core that the previous link order happened to mask.

## What we lose by reverting

- The EnchantItem guard against bad seed-data slot pairings (rare path; not blocking).
- The vendored playerbots in-tree (lose the ability to land local patches).
- The new SQL migration runner / baked migration tree (not auto-invoked, so functionally a no-op anyway).

## Next steps after this lands

1. Confirm pod stays Running for ≥15 min (one full bot tick cycle).
2. Investigate the SIGSEGV on the `2de514e3` build separately — rebuild with `-g` for symbols, repro under load, then re-roll the vendoring with the fix.

## Test plan

- [ ] CI: flux-local diff/test passes
- [ ] Merge + Flux reconciles cmangos HelmRelease
- [ ] Pod transitions from CrashLoopBackOff → Running, stays up ≥15 min
- [ ] `kubectl logs -n game-servers deploy/cmangos-mangosd -c app --tail=200` shows clean boot + steady-state activity