### PR TITLE
feat(cmangos): enable LLM chat on live (Ollama qwen2.5:3b)

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
@@ -357,6 +357,49 @@ spec:
             # and stops k8s container-log rotation from evicting useful
             # lines within seconds. Grouped bots still get full traces.
             AiPlayerbot.LogInGroupOnly = 1
+            # LLM-driven chat — points at the in-cluster Ollama
+            # (ai-system ns, qwen2.5:3b ~1.9GB). PlayerbotLLMInterface
+            # is async by design and drops requests above
+            # MaxSimultaniousGenerations, so this cannot block bot
+            # tick threads even at the current 1500-2000 bot density
+            # on live. The binary already carries PR #13's
+            # try/catch around every std::regex(...) in
+            # PlayerbotLLMInterface.cpp (image 97851d0e), so an
+            # invalid response-parsing pattern degrades gracefully
+            # via sLog.outError instead of crashing the world server.
+            #
+            # Same settings as PTR after the prompt-tuning soak:
+            # - Mode 2 = LLM default for all bots (no per-bot strategy)
+            # - max 25 concurrent generations (qwen2.5:3b on CPU does
+            #   ~5-10 gens/s; 25 caps sustainable backpressure)
+            # - 30s timeout drops slow gens rather than holding state
+            # - Bot-to-bot chat OFF (avoid LLM-vs-LLM loops)
+            # - RPG-AI chat ON (full chance during RPG interactions)
+            #
+            # Only the StartPattern is overridden because Ollama
+            # returns the OpenAI-compat schema ("content":"...") not
+            # KoboldAI ("text":"..."), and it's deliberately
+            # backslash-free — the cmangos .conf parser strips
+            # single backslashes from values, so any pattern with
+            # \s or \* or \[ in the config gets reduced to s/*/[ and
+            # becomes invalid regex. End/Delete/Split overrides are
+            # omitted so the (working) R"(...)" code defaults in
+            # PlayerbotAIConfig.cpp:678-681 take effect — those
+            # bypass the parser entirely.
+            AiPlayerbot.LLMEnabled = 2
+            AiPlayerbot.LLMApiEndpoint = http://ollama.ai-system.svc.cluster.local:11434/v1/chat/completions
+            AiPlayerbot.LLMApiKey =
+            AiPlayerbot.LLMApiJson = {"model": "qwen2.5:3b", "messages": [{"role": "system", "content": "<pre prompt> <context>"},{"role": "user", "content": "<prompt>"}],"max_tokens": 60}
+            AiPlayerbot.LLMContextLength = 4096
+            AiPlayerbot.LLMGenerationTimeout = 30
+            AiPlayerbot.LLMMaxSimultaniousGenerations = 25
+            AiPlayerbot.LLMPrePrompt = You are <bot name>, a level <bot level> <bot gender> <bot race> <bot class> in <bot subzone>, <bot zone>. <other name> (level <other level> <other gender> <other race> <other class>) just sent you a <channel name>. Reply like a real WoW Classic player would in chat: brief, casual, lowercase fine, shorthand fine (ty, wb, brb, lol, omw, gtg, np, k). React to what they said. Drop in your current activity (quest, grind spot, looking for group, heading to a city) when it fits naturally. Stay in character at all times — you are this character, in this world, right now. Never mention being an AI, "the game", interfaces, mechanics, or anything outside the world. Under 100 characters.
+            AiPlayerbot.LLMPrompt = <receiver name>:<initial message>
+            AiPlayerbot.LLMPostPrompt = <bot name>:
+            AiPlayerbot.LLMRpgPrompt = You are <bot name>, a level <bot level> <bot gender> <bot race> <bot class>, standing in <bot subzone>, <bot zone>. Nearby is <unit name>, a <unit type> — a level <unit level> <unit gender> <unit race> <unit faction> <unit class>. Say something a real WoW Classic player would say in passing: a quick comment, observation, greeting, or in-character muttering about what you're doing. Casual chat tone, lowercase fine, shorthand fine. Reference your class, zone, or current activity if it fits. Stay in character: no AI talk, no game-mechanic talk, no fourth wall. Under 100 characters.
+            AiPlayerbot.LLMResponseStartPattern = ("content":")
+            AiPlayerbot.LLMBotToBotChatChance = 0
+            AiPlayerbot.LLMRpgAIChatChance = 100
       twinkmaster-config:
         data:
           twinkmaster.conf: |


### PR DESCRIPTION
## Summary

Brings live's playerbot chat to the same LLM-driven setup that's been running on PTR. Bots will respond to whispers (and occasionally RPG-chat near players) via the in-cluster Ollama deployment (`ai-system/ollama`, `qwen2.5:3b`, OpenAI-compat `/v1/chat/completions`).

Live's binary already carries the safety net (`97851d0e`, post-PR #13 merge of `xunholy/cmangos-classic#13`): every `std::regex(...)` site in `PlayerbotLLMInterface.cpp` is wrapped in try/catch, so an invalid response-parsing pattern logs `sLog.outError` instead of crashing the world server. This PR just turns the feature on.

## Config — verbatim from PTR after the tone-tuning iteration converged

- `LLMEnabled = 2` — default for all bots, no per-bot strategy gate needed
- `LLMApiEndpoint = http://ollama.ai-system.svc.cluster.local:11434/v1/chat/completions`
- `LLMApiJson` — OpenAI-compat with `model: "qwen2.5:3b", max_tokens: 60`
- `LLMMaxSimultaniousGenerations = 25` — qwen2.5:3b on CPU does ~5-10 gens/s; 25 caps backpressure
- `LLMGenerationTimeout = 30s` — drop stuck gens
- `LLMBotToBotChatChance = 0` — avoid LLM-vs-LLM chat loops
- `LLMRpgAIChatChance = 100` — RPG NPC interactions fire fully
- `LLMResponseStartPattern = ("content":")` — overridden for OpenAI schema, deliberately backslash-free (cmangos `.conf` parser strips single backslashes from values; End/Delete/Split overrides omitted so the working `R"(...)"` code defaults take effect)
- Tone-tuned `LLMPrePrompt` and `LLMRpgPrompt` — first-person framing, casual MMO chat register, explicit fourth-wall guard

## Safety analysis

| Concern | Mitigation |
|---|---|
| LLM call blocks bot tick? | `PlayerbotLLMInterface` is async by design (file header comment confirms) + drops requests above the cap |
| Bad regex crashes mangosd? | PR #13's try/catch already in the live binary (`97851d0e`) — fail-soft, log + degrade |
| Ollama saturation? | `MaxSimultaniousGenerations = 25` cap |
| Bot population overload? | No change to bot config (`Min=1500, Max=2000`) |
| Player downtime on apply? | ConfigMap change triggers a full Recreate cycle (240s in-game countdown + 260s drain). **Merge this PR only during a 0-human-online window** — same gate as the previous binary promotion |

## Test plan
- [x] PTR ran this exact config with `qwen2.5:3b` under `bots=1500/2000` — bot whispers reply via LLM, no crashes, regex try/catch logged + degraded any bad patterns gracefully
- [x] Tone-tuned prompts soaked on PTR
- [ ] Merge during 0-human window on live; verify new pod 3/3 Running with 0 restarts and bots start replying to whispers