### PR TITLE
feat(ollama): explicit OLLAMA_NUM_PARALLEL=4 + size for inference

### DIFF
--- a/kubernetes/apps/base/ai-system/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/base/ai-system/ollama/app/helmrelease.yaml
@@ -23,12 +23,32 @@ spec:
       models:
         pull:
           - qwen2.5:3b
+    # OLLAMA_NUM_PARALLEL controls how many requests Ollama processes
+    # in parallel against a single loaded model. Default auto-selects
+    # 4 if the model fits in RAM 4x over, otherwise 1. Setting it
+    # explicitly removes the guesswork and survives memory-limit
+    # tuning. OLLAMA_KEEP_ALIVE keeps the model resident across idle
+    # gaps (default 5m); the cmangos playerbot integration hits the
+    # endpoint in unpredictable bursts (whisper-driven), so 24h keeps
+    # qwen2.5:3b hot and avoids the first-request reload penalty.
+    extraEnv:
+      - name: OLLAMA_NUM_PARALLEL
+        value: "4"
+      - name: OLLAMA_KEEP_ALIVE
+        value: "24h"
     resources:
+      # CPU request bumped 500m -> 4 so the scheduler actually reserves
+      # the cores qwen2.5:3b needs to run 4 parallel inferences. With
+      # 500m we were vulnerable to neighbour-pod contention dropping
+      # generation rate from ~10 tok/s to ~2 tok/s.
+      # Memory bumped 4Gi -> 6Gi request / 8Gi -> 10Gi limit to fit
+      # 4x ~1.9GB model copies (one per parallel slot) plus working
+      # memory + KV cache.
       requests:
-        cpu: 500m
-        memory: 4Gi
+        cpu: "4"
+        memory: 6Gi
       limits:
-        memory: 8Gi
+        memory: 10Gi
     persistentVolume:
       enabled: true
       storageClass: ceph-block


### PR DESCRIPTION
## Summary

Sizes the in-cluster Ollama (`ai-system/ollama`, `qwen2.5:3b`) for the cmangos playerbot LLM-chat integration. Today the deployment is configured for "loads a model and idles" — fine for a single test request, undersized for the bot-driven traffic that will land once the live LLM-enable PR (#4067) merges.

## Changes

### `extraEnv`
| Var | Value | Why |
|---|---|---|
| `OLLAMA_NUM_PARALLEL` | `"4"` | Explicit; Ollama auto-detects 4 only when memory headroom permits, so setting it removes the guess and decouples parallelism from future memory tuning |
| `OLLAMA_KEEP_ALIVE` | `"24h"` | Default `5m`; whisper traffic is bursty, so a gap > 5m forces a model reload (1-2s penalty). 24h keeps `qwen2.5:3b` hot |

### `resources`
| | Before | After | Why |
|---|---|---|---|
| CPU request | `500m` | `"4"` | 4 parallel inferences need real cores reserved; at 500m one noisy-neighbour pod was enough to drop generation from ~10-20 tok/s to ~2 tok/s |
| Memory request | `4Gi` | `6Gi` | 4× ~1.9GB model copies + KV cache + working memory |
| Memory limit | `8Gi` | `10Gi` | Matches the request bump so the pod is Guaranteed-tier QoS for memory |

## Capacity expectation

- **Today**: ~0.8 sustained chat completions/sec (often serialising because of CPU starvation)
- **After**: ~3 sustained chat completions/sec, burst ~25 in flight before the cmangos `LLMMaxSimultaniousGenerations=25` cap drops requests
- Latency floor stays ~2-3s for short responses — to go faster you need GPU acceleration (separate effort)

## Risk / safety

- Single-replica deployment → reconcile = pod restart, ~30-60s for PVC remount + model preload
- Not gated on humans: the only consumer today is PTR. The pending live LLM PR (#4067) has its own 0-human-online merge gate
- No API or interface changes; pure resource sizing + env hygiene

## Test plan

- [ ] Merge → watch pod restart, model reload, then verify PTR's `Avg Diff` and bot whisper response time don't regress
- [ ] After settling: send 10-20 rapid whispers to PTR bots, confirm Ollama log shows responses landing in ~2-3s instead of stacking past 7s
- [ ] CPU saturation check: `kubectl -n ai-system top pod -l app.kubernetes.io/name=ollama` under load should be 2-4 cores, not 0.5