### PR TITLE
feat(cmangos-ptr): soak guard-rails + Attuner announcements (709056456)

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
@@ -143,7 +143,16 @@ spec:
               # branched off main (8fc4bbbc), so it does NOT carry the PR #21
               # Dashel/Missing-Diplomat fix — intentionally, to isolate the
               # crash fix under multi-threaded map update. GH PR test-merge SHA.
-              tag: f086a251beb33e76c515e41ab1c4a9c7b8e091df
+              # 2026-06-18: bumped to 709056456 (branch ptr/guardrails-attuner =
+              # harden/ptr-guardrails + Feature 1 cherry-pick). f086a251 still
+              # SIGSEGV'd ~1x/8-12h under bot load (playerbot movement / UAF) and
+              # spammed 40k+ "MySQL server has gone away". This image adds the
+              # upstream-sync playerbot fixes + GetStmt fail-soft hardening (so a
+              # failed prepared stmt no longer aborts the realm) AND the periodic
+              # Attuner-of-Paths announcement, to soak both at once. workflow_dispatch
+              # SHA (branch tip, NOT a PR merge SHA — keeps paladinpower build state
+              # identical to the prior image).
+              tag: 7090564565a86bcd4f41987e5c0f75d55b659047
             args: ["mangosd"]
             tty: true
             stdin: true


### PR DESCRIPTION
Bumps the **PTR** image `f086a251` → `7090564565a86bcd4f41987e5c0f75d55b659047`.

Branch `ptr/guardrails-attuner` = `harden/ptr-guardrails` + Feature 1 cherry-pick (attunement-only, 5 files, no conflicts).

### Why
PTR's current image (GridMap guard only) is **still crashing**: SIGSEGV ~1×/8–12h under bot load (2 core dumps in 24h), pre-crash logs flooded with playerbot movement errors (`AbstractPathMovementGenerator`, spline movement, `entry 0` bots) + `Max Diff 1720ms`. Not OOM (7.7Gi/20Gi). Also 843MB DBErrors.log, 40k+ "server has gone away".

### What this image adds
- **upstream-sync playerbot fixes** (the movement/UAF crash class)
- **GetStmt fail-soft hardening** — a failed prepared statement returns null instead of aborting the realm
- **Periodic Attuner-of-Paths announcement** (Feature 1) — the feature to test

Soaks stability + feature together on PTR. **Live is unaffected** (separate SHA pin). `workflow_dispatch` build SHA (branch tip, not a PR-merge SHA — keeps paladinpower build state identical to the prior image).

> ⚠️ Do not merge until the `:709056456…` image is confirmed pushed to ghcr (build run 27715744958), else ImagePullBackOff.