### PR TITLE
fix(cmangos-ptr): revert MapUpdate.Threads 3->1 (transport passenger UAF under N>1)

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
@@ -327,7 +327,19 @@ spec:
             # fixes hold up against the original concurrency hazard.
             # If a new crash class surfaces under N=3, revert here and
             # capture the core.
-            MapUpdate.Threads = 3
+            #
+            # 2026-06-18: REVERTED 3 → 1. Soak of image 709056456
+            # (guard-rails + Attuner announce) under N=3 SIGSEGV'd within
+            # ~2.5h. Clean 7.3G core backtrace pinned a SECOND, distinct
+            # multi-thread crash vector (separate from the GridMap OOB
+            # already fixed): a transport passenger use-after-free —
+            # GenericTransport::UpdatePassengerPosition deref'd a garbage
+            # passenger ptr (rsi=0x1) because Transport::Update iterates
+            # _passengers while another map-worker mutates it. N=1
+            # serializes transport updates and avoids it (which is why
+            # live on N=1 is unaffected). Re-bump to test only after the
+            # _passengers iteration is made thread-safe.
+            MapUpdate.Threads = 1
             Motd = "Welcome to Emberstone PTR"
             # Match live: LogLevel=1 keeps kubectl logs clean, LogFile
             # captures full diagnostics on the PVC.


### PR DESCRIPTION
PTR soak of image `709056456` (guard-rails + Attuner announce) under `MapUpdate.Threads=3` **SIGSEGV'd within ~2.5h**.

A clean 7.3G core (captured thanks to the freshly-emptied cores PVC) backtraced to:
```
#0 GenericTransport::UpdatePassengerPosition(WorldObject*)   ← passenger ptr rsi=0x1 (garbage)
#1 Transport::Update(unsigned int)
#2 Map::Update(unsigned int const&)
#3 MapUpdateWorker::execute()                                 ← map-update worker thread
```

This is a **second, distinct multi-thread crash vector**, separate from the GridMap OOB already fixed: `Transport::Update` iterates the transport's `_passengers` set while another map-update worker mutates it (a unit boarding/leaving) → iteration yields a garbage pointer → UAF deref.

`MapUpdate.Threads=1` serializes transport updates and avoids the race — which is exactly why **live (already on N=1) is unaffected**. This reverts PTR to N=1 so it matches live and stops crashing, letting Feature 1 (Attuner announcements) be tested on a stable realm.

Re-bump to N=3 only after `_passengers` iteration is made thread-safe. Config-only change → PTR pod restart on reconcile. Live untouched.