### PR TITLE
fix(cmangos-database): bump memory 2Gi->4Gi (OOMKill broke auth for ~40min)

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos-database/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-database/app/helmrelease.yaml
@@ -73,9 +73,16 @@ spec:
             resources:
               requests:
                 cpu: "1"
-                memory: 512Mi
+                # 2026-06-18: bumped 512Mi -> 1Gi. The 2Gi limit was OOMKilled
+                # (exit 137) during a PTR rollover when both realms' bots
+                # reconnected at once (max_connections=151 x per-connection
+                # buffers spiking past 2Gi). The OOM severed realmd's DB
+                # connection and realmd did NOT auto-reconnect, breaking all
+                # logins for ~40min until realmd was restarted. More headroom
+                # prevents the OOM that triggers that cascade.
+                memory: 1Gi
               limits:
-                memory: 2Gi
+                memory: 4Gi
     # bjw-s app-template singleton-collapse: with one controller + one
     # service + zero ConfigMaps, the Deployment and Service both render
     # as just `cmangos-database` (not `cmangos-database-database` /


### PR DESCRIPTION
The shared `cmangos-database` (MariaDB) was **OOMKilled** (exit 137) during a PTR rollover when both realms' bots reconnected simultaneously — `max_connections=151` × per-connection buffers spiked past the **2Gi** limit (buffer pool is only 128MB, so this is connection-buffer pressure, not InnoDB).

**Blast radius:** the OOM severed realmd's DB connection, and **realmd did not auto-reconnect** → every login query failed with "Server has gone away" → **all logins broken for ~40 min** until realmd was manually restarted.

**Fix:** requests `512Mi → 1Gi`, limits `2Gi → 4Gi` for headroom against reconnect storms.

⚠️ Applying this **restarts the DB pod once**; realmd will be restarted immediately after to re-establish its connection (handled out-of-band). Brief (~1-2 min) auth blip on reconcile.

Follow-up (separate): realmd should auto-recover from a dropped DB connection instead of needing a manual restart.