### PR TITLE
feat(cmangos-ptr): Attuner announcement MonsterYell fix (932e0d72d)

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
@@ -152,7 +152,10 @@ spec:
               # Attuner-of-Paths announcement, to soak both at once. workflow_dispatch
               # SHA (branch tip, NOT a PR merge SHA — keeps paladinpower build state
               # identical to the prior image).
-              tag: 7090564565a86bcd4f41987e5c0f75d55b659047
+              # 2026-06-19: bumped to 932e0d72d — the Attuner announcement used
+              # MonsterSay (~25yd local), so it was invisible beyond the NPC.
+              # Switched to MonsterYell so it carries across the capital-city hub.
+              tag: 932e0d72d9e80c015d803f602dae0c875beb016a
             args: ["mangosd"]
             tty: true
             stdin: true


### PR DESCRIPTION
Bumps PTR `709056456` → `932e0d72d`. The Attuner-of-Paths periodic announcement used `MonsterSay` (~25yd local), invisible beyond the NPC. Switched to `MonsterYell` (carries across the capital-city hub). Image confirmed in ghcr. Live unaffected (separate pin).