### PR TITLE
feat(cmangos-ptr): dedicated MariaDB for PTR [DO NOT MERGE — gated]

### DIFF
--- a/kubernetes/apps/base/flux-system/artifact-generator/artifactgenerator.yaml
+++ b/kubernetes/apps/base/flux-system/artifact-generator/artifactgenerator.yaml
@@ -75,6 +75,11 @@ spec:
       copy:
         - from: "@repo/apps/base/game-servers/cmangos-ptr/app/"
           to: "@artifact/apps/base/game-servers/cmangos-ptr/app/"
+    - name: cmangos-ptr-database
+      originRevision: "@repo"
+      copy:
+        - from: "@repo/apps/base/game-servers/cmangos-ptr-database/app/"
+          to: "@artifact/apps/base/game-servers/cmangos-ptr-database/app/"
     - name: cmangos-realmd
       originRevision: "@repo"
       copy:

--- a/kubernetes/apps/base/game-servers/cmangos-ptr-database/app/externalsecret.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr-database/app/externalsecret.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+#
+# Dedicated creds for the PTR MariaDB instance. Kept separate from the shared
+# cmangos-database-creds (which feeds LIVE mangosd/realmd/database) so that the
+# DB_ROOT_PASSWORD dependency below can never disrupt live auth if it's missing.
+#
+# PREREQUISITE: add a DB_ROOT_PASSWORD field to the `cmangos` 1Password item
+# before this merges. Without it the root key renders empty and the PTR MariaDB
+# first-init fails — but live is unaffected.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cmangos-ptr-database-creds
+  namespace: game-servers
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: cmangos-ptr-database-creds
+    template:
+      data:
+        # App user — same identity as live so PTR mangosd's existing
+        # MANGOS_DBUSER/MANGOS_DBPASS work unchanged against this instance.
+        # MARIADB_* are first-init only; MANGOS_* are read by the db-init Job
+        # to dump the clone source from the live shared instance.
+        MANGOS_DBUSER: "{{ .DB_USER }}"
+        MANGOS_DBPASS: "{{ .DB_PASSWORD }}"
+        MARIADB_USER: "{{ .DB_USER }}"
+        MARIADB_PASSWORD: "{{ .DB_PASSWORD }}"
+        # Root, first-init only — the db-init Job needs it to CREATE DATABASE
+        # + GRANT on this fresh instance.
+        MARIADB_ROOT_PASSWORD: "{{ .DB_ROOT_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: cmangos

--- a/kubernetes/apps/base/game-servers/cmangos-ptr-database/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr-database/app/helmrelease.yaml
@@ -1,0 +1,80 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+#
+# Dedicated MariaDB for Emberstone PTR — hosts ptrmangos / ptrcharacters /
+# ptrlogs only. The shared auth DB (classicrealmd) stays on cmangos-database;
+# PTR's mangosd points its login-DB connection there via MANGOS_REALMD_DBHOST
+# (see cmangos-ptr/app/helmrelease.yaml). Splitting PTR's world/character load
+# off the shared instance removes the connection + buffer contention that
+# OOM-killed the shared DB and broke live logins on 2026-06-18.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cmangos-ptr-database
+  namespace: game-servers
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  values:
+    controllers:
+      database:
+        containers:
+          app:
+            image:
+              repository: mariadb
+              tag: "12.2"
+            env:
+              TZ: ${CLUSTER_TIMEZONE}
+            envFrom:
+              # First-init credentials from the dedicated PTR-DB secret (see
+              # externalsecret.yaml). App user matches live so PTR mangosd's
+              # existing creds work; root is needed by the cmangos-ptr db-init
+              # Job. Kept separate from the shared cmangos-database-creds so the
+              # DB_ROOT_PASSWORD prerequisite can't affect live auth.
+              - secretRef:
+                  name: cmangos-ptr-database-creds
+            probes:
+              liveness: &dbprobe
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ['healthcheck.sh', '--connect', '--innodb_initialized']
+                  periodSeconds: 30
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              readiness: *dbprobe
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ['healthcheck.sh', '--connect', '--innodb_initialized']
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: "1"
+                memory: 1Gi
+              limits:
+                memory: 4Gi
+    # bjw-s singleton-collapse: one controller + one service + zero ConfigMaps
+    # renders the Deployment and Service both as `cmangos-ptr-database`, which
+    # is the DNS name cmangos-ptr mangosd connects to via MANGOS_DBHOST.
+    service:
+      database:
+        controller: database
+        ports:
+          mysql:
+            port: 3306
+    persistence:
+      data:
+        existingClaim: cmangos-ptr-database
+        advancedMounts:
+          database:
+            app:
+              - path: /var/lib/mysql

--- a/kubernetes/apps/base/game-servers/cmangos-ptr-database/app/kustomization.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr-database/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# No VolSync ReplicationSource here by design: PTR data is reconstructible.
+# ptrmangos is a clone of live's classicmangos, ptrcharacters/ptrlogs are
+# schema-only and GM-only. The cmangos-ptr db-init Job IS the recovery path,
+# so a backup repo would be redundant maintenance. Add one later only if PTR
+# ever holds something worth keeping.
+resources:
+  - helmrelease.yaml
+  - externalsecret.yaml
+  - pvc-database.yaml

--- a/kubernetes/apps/base/game-servers/cmangos-ptr-database/app/pvc-database.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr-database/app/pvc-database.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cmangos-ptr-database
+  namespace: game-servers
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/base/game-servers/cmangos-ptr-database/ks.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr-database/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cmangos-ptr-database
+  namespace: game-servers
+  labels:
+    gitops.owncloud.ai/defaults: disabled
+spec:
+  decryption:
+    provider: sops
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m
+  path: "./apps/base/game-servers/cmangos-ptr-database/app"
+  prune: true
+  wait: true
+  sourceRef:
+    kind: ExternalArtifact
+    name: cmangos-ptr-database
+    namespace: flux-system
+  dependsOn:
+    - name: onepassword
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  targetNamespace: game-servers

--- a/kubernetes/apps/base/game-servers/cmangos-ptr/app/db-init-job.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr/app/db-init-job.yaml
@@ -22,27 +22,35 @@ spec:
       initContainers:
         - name: wait-db
           image: busybox:latest
-          command: ['sh', '-c', 'until nc -z cmangos-database 3306; do echo "Waiting for database..."; sleep 2; done']
+          command: ['sh', '-c', 'until nc -z cmangos-ptr-database 3306 && nc -z cmangos-database 3306; do echo "Waiting for databases..."; sleep 2; done']
       containers:
         - name: init
           image: mariadb:12.2
-          # CREATE DATABASE + GRANT must be run as root (the app user lacks
-          # global CREATE). Dumps + restores then run as root too, since
-          # we already have a root session here. App-user grants are what
-          # the runtime PTR mangosd actually needs — username from secret.
+          # Uses the dedicated PTR-DB secret: MARIADB_ROOT_PASSWORD to admin
+          # the new instance (CREATE DATABASE + GRANT — the app user lacks
+          # global CREATE) and MANGOS_DBUSER/MANGOS_DBPASS to read the clone
+          # source from the live shared instance. Same 1Password item as the
+          # shared creds, so the app-user identity matches live.
           envFrom:
             - secretRef:
-                name: cmangos-database-creds
-          env:
-            - name: ROOT_PWD
-              value: password
+                name: cmangos-ptr-database-creds
           command:
             - /bin/bash
             - -c
             - |
               set -euo pipefail
-              MARIADB="mariadb -h cmangos-database -P 3306 -u root -p$${ROOT_PWD}"
-              DUMP="mariadb-dump -h cmangos-database -P 3306 -u root -p$${ROOT_PWD} --single-transaction --routines --triggers"
+              # Admin on the NEW PTR instance (CREATE DATABASE + GRANT + the
+              # restore target). Root password from the secret, not a literal
+              # — this is the fresh instance's first-init root (DB_ROOT_PASSWORD).
+              MARIADB="mariadb -h cmangos-ptr-database -P 3306 -u root -p$${MARIADB_ROOT_PASSWORD}"
+              # Read the clone source from the LIVE shared instance as the
+              # least-privilege app user (already has SELECT on the classic*
+              # DBs) — no live root needed. --single-transaction = consistent
+              # snapshot without locking live. --routines dropped: the app user
+              # may lack routine-read on the source, and cmangos world content
+              # doesn't rely on stored routines; re-add (and grant) if a clone
+              # ever needs them.
+              DUMP="mariadb-dump -h cmangos-database -P 3306 -u $${MANGOS_DBUSER} -p$${MANGOS_DBPASS} --single-transaction --triggers"
 
               already_seeded() {
                 local db=$1
@@ -75,9 +83,11 @@ spec:
                 echo "=== Cloning classiccharacters -> ptrcharacters (schema + version row) ==="
                 $${DUMP} --no-data classiccharacters | $${MARIADB} ptrcharacters
                 # mangosd refuses to boot without a row in *_db_version
-                # (compatibility check). Copy the live row so PTR runs
-                # against whatever schema rev live is on.
-                $${MARIADB} -e "INSERT INTO ptrcharacters.character_db_version SELECT * FROM classiccharacters.character_db_version;"
+                # (compatibility check). The source table now lives on a
+                # DIFFERENT instance, so copy it with a single-table dump
+                # (drop+create+insert) instead of a cross-instance
+                # INSERT...SELECT, which can't see classiccharacters from here.
+                $${DUMP} classiccharacters character_db_version | $${MARIADB} ptrcharacters
               fi
 
               if already_seeded ptrlogs; then
@@ -85,7 +95,8 @@ spec:
               else
                 echo "=== Cloning classiclogs -> ptrlogs (schema + version row) ==="
                 $${DUMP} --no-data classiclogs | $${MARIADB} ptrlogs
-                $${MARIADB} -e "INSERT INTO ptrlogs.logs_db_version SELECT * FROM classiclogs.logs_db_version;"
+                # Single-table dump across instances (see character_db_version above).
+                $${DUMP} classiclogs logs_db_version | $${MARIADB} ptrlogs
               fi
 
               echo "=== Done. Table counts: ==="

--- a/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
@@ -58,7 +58,9 @@ spec:
             image:
               repository: busybox
               tag: latest
-            command: ['sh', '-c', 'until nc -z cmangos-database 3306; do sleep 2; done']
+            # PTR now spans two instances: its own DB (world/chars/logs) and
+            # the shared DB (classicrealmd auth). Wait for both before boot.
+            command: ['sh', '-c', 'until nc -z cmangos-ptr-database 3306 && nc -z cmangos-database 3306; do sleep 2; done']
         containers:
           app:
             image:
@@ -161,11 +163,19 @@ spec:
             stdin: true
             env:
               TZ: ${CLUSTER_TIMEZONE}
-              MANGOS_DBHOST: cmangos-database
+              # World / characters / logs live on the dedicated PTR instance.
+              MANGOS_DBHOST: cmangos-ptr-database
               MANGOS_DBPORT: "3306"
-              # Auth DB is shared with live so accounts/GM flags carry over.
+              # Auth DB stays on the shared instance — realmlist, accounts,
+              # session keys. Shared with live so accounts/GM flags carry over.
+              # REQUIRES image entrypoint support for a separate login-DB host
+              # (MANGOS_REALMD_DBHOST). Without it the login lookup wrongly
+              # targets cmangos-ptr-database (no classicrealmd there) and all
+              # PTR logins fail. See the PR description for the fork image
+              # prerequisite — DO NOT MERGE until that image is shipped + pinned.
+              MANGOS_REALMD_DBHOST: cmangos-database
               MANGOS_REALMD_DBNAME: classicrealmd
-              # Game state isolated from live.
+              # Game state isolated from live (on MANGOS_DBHOST above).
               MANGOS_WORLD_DBNAME: ptrmangos
               MANGOS_CHARACTERS_DBNAME: ptrcharacters
               MANGOS_LOGS_DBNAME: ptrlogs

--- a/kubernetes/apps/base/game-servers/cmangos-ptr/ks.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr/ks.yaml
@@ -20,7 +20,12 @@ spec:
     kind: ExternalArtifact
     name: cmangos-ptr
     namespace: flux-system
-  # No dependsOn on cmangos — DB is now in cmangos-database, and the
-  # PTR pod's own wait-db init container handles runtime ordering.
-  # Keeps PTR reconcilable when the main world server is in a bad state.
+  # No dependsOn on cmangos — keeps PTR reconcilable when the main world
+  # server is in a bad state. But PTR now has its own dedicated DB
+  # (cmangos-ptr-database) which owns the cmangos-ptr-database-creds secret
+  # the db-init Job envFroms, so gate on that so the secret exists before
+  # the Job runs. Auth (classicrealmd) still lives on the shared instance.
+  dependsOn:
+    - name: cmangos-ptr-database
+      namespace: game-servers
   targetNamespace: game-servers

--- a/kubernetes/apps/overlays/cluster-00/kustomization.yaml
+++ b/kubernetes/apps/overlays/cluster-00/kustomization.yaml
@@ -48,6 +48,7 @@ resources:
   # - ../../base/game-servers/minecraft-router/ks.yaml
   - ../../base/game-servers/cmangos/ks.yaml
   - ../../base/game-servers/cmangos-database/ks.yaml
+  - ../../base/game-servers/cmangos-ptr-database/ks.yaml
   - ../../base/game-servers/cmangos-ptr/ks.yaml
   - ../../base/game-servers/cmangos-realmd/ks.yaml
   - ../../base/game-servers/adminer/ks.yaml


### PR DESCRIPTION
> [!CAUTION]
> **DO NOT MERGE.** Gated on two external prerequisites (below). Kept as a draft so it can't merge accidentally. Merging without these breaks all PTR logins and/or PTR DB init.

## What

Moves PTR's `ptrmangos` / `ptrcharacters` / `ptrlogs` onto a **dedicated** MariaDB (`cmangos-ptr-database`). The shared `cmangos-database` keeps only the auth DB (`classicrealmd`) + live's game DBs. This removes the world/character connection + buffer-pool contention that OOM-killed the shared instance and broke **live** logins on 2026-06-18.

`classicrealmd` (realmlist + accounts + session keys) **stays shared**, so single-auth / both-realms-visible / GM-flags-carry-over is unchanged. PTR's mangosd becomes the only cross-instance client (login → shared, world/char/logs → its own box).

## ⛔ Prerequisites (do both before un-drafting)

1. **Fork image** — add `MANGOS_REALMD_DBHOST` to the entrypoint in `xunholy/cmangos-classic` so the login DB can be on a different host than world/char/logs, defaulting to `MANGOS_DBHOST` (so live/realmd are unaffected). Build + pin the PTR image. **Without it, PTR login lookups hit the new instance, find no `classicrealmd`, and every PTR login fails.**
2. **1Password** — add a `DB_ROOT_PASSWORD` field to the `cmangos` item. The new `cmangos-ptr-database-creds` ExternalSecret needs it for first-init root. Scoped to a dedicated secret so a missing key can't disrupt live auth.

## Changes

- **New `cmangos-ptr-database` app**: HelmRelease (mariadb:12.2), PVC (10Gi), dedicated `ExternalSecret`, `ks.yaml`; registered in the ArtifactGenerator + cluster-00 overlay. No VolSync — PTR data is reconstructible via the db-init Job.
- **`cmangos-ptr`**: `MANGOS_DBHOST` → `cmangos-ptr-database`; add `MANGOS_REALMD_DBHOST=cmangos-database`; `wait-db` waits for both instances; `dependsOn: cmangos-ptr-database` (it owns the creds secret the Job uses).
- **`db-init` Job** → cross-instance clone: read live as the app user, create/grant/restore on the new instance as root; `*_db_version` rows copied via single-table dumps (cross-instance `INSERT…SELECT` can't work anymore).
- Shared `cmangos-database-creds` / `externalsecret-database.yaml` **untouched**.

## Cutover (once prerequisites are met)

1. Ship + PTR-pin the image (prereq 1); confirm live still boots (default-fallback path).
2. Add `DB_ROOT_PASSWORD` to 1Password (prereq 2).
3. Mark ready + merge → `cmangos-ptr-database` comes up; `db-init` clones `ptr*` onto it; PTR mangosd rolls onto the new instance.
4. Verify a GM login + a bot spawn on PTR.
5. **Reclaim**: `DROP DATABASE ptrmangos/ptrcharacters/ptrlogs` on the shared `cmangos-database` — this is what actually relieves the shared instance.

**Rollback** before step 5: revert the `cmangos-ptr` env change (points back at `cmangos-database`, old `ptr*` still there). Instant, no data loss.

## Validation done

- `kustomize build` new app dir → ExternalSecret + HelmRelease + PVC render
- `kustomize build --load-restrictor LoadRestrictionsNone overlays/cluster-00` → 153 docs
- yamllint + full pre-commit suite → passed
- Coherence: `realm-row-migration` still writes shared `classicrealmd`; db-init admins new instance / reads live

https://claude.ai/code/session_01T37E9UJr2ymcGhQoV8Yq93