### PR TITLE
feat(cmangos-database): nightly logical (mysqldump) backups

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos-database/app/backup-cronjob.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-database/app/backup-cronjob.yaml
@@ -1,0 +1,91 @@
+---
+# Nightly logical backup of the irreplaceable game DBs (accounts + characters).
+# Complements the hourly crash-consistent RBD snapshot (replicationsource.yaml)
+# with restorable, engine-independent SQL dumps — the MyISAM tables in these
+# DBs aren't safe to restore from a raw volume snapshot mid-write.
+#
+# classicmangos (world) is intentionally NOT dumped: it's reconstructible via
+# init-db + the in-repo migration Jobs. classiclogs is disposable.
+#
+# $$ escapes are for Flux post-build substitution (only ${CLUSTER_TIMEZONE} is
+# a Flux var; everything else is runtime bash).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cmangos-db-logical-backup
+  namespace: game-servers
+spec:
+  schedule: "0 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: dump
+              image: mariadb:12.2
+              envFrom:
+                # MANGOS_DBUSER / MANGOS_DBPASS — SELECT is enough for the
+                # --single-transaction dump below.
+                - secretRef:
+                    name: cmangos-database-creds
+              env:
+                - name: TZ
+                  value: ${CLUSTER_TIMEZONE}
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+                  BACKUP_DIR=/backup
+                  DBS="classicrealmd classiccharacters"
+                  RETAIN=7
+                  TS=$$(date +%Y%m%d-%H%M%S)
+
+                  for db in $$DBS; do
+                    out="$${BACKUP_DIR}/$${db}-$${TS}.sql.gz"
+                    echo "Dumping $${db} -> $${out}"
+                    # --single-transaction: consistent snapshot of the InnoDB
+                    # bulk (all player rows) with no write-blocking. The few
+                    # small MyISAM tables are best-effort. --no-tablespaces
+                    # avoids needing the PROCESS privilege, so SELECT suffices.
+                    mariadb-dump -h cmangos-database -P 3306 \
+                      -u "$${MANGOS_DBUSER}" -p"$${MANGOS_DBPASS}" \
+                      --single-transaction --quick --no-tablespaces \
+                      "$${db}" | gzip -c > "$${out}"
+                  done
+
+                  echo "Pruning to newest $${RETAIN} per DB"
+                  for db in $$DBS; do
+                    # shellcheck disable=SC2012
+                    ls -1t "$${BACKUP_DIR}/$${db}-"*.sql.gz 2>/dev/null \
+                      | tail -n +$$((RETAIN + 1)) | xargs -r rm -f --
+                  done
+
+                  echo "Backups on volume:"
+                  ls -lh "$${BACKUP_DIR}"
+              volumeMounts:
+                - name: dumps
+                  mountPath: /backup
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: dumps
+              persistentVolumeClaim:
+                claimName: cmangos-db-dumps

--- a/kubernetes/apps/base/game-servers/cmangos-database/app/kustomization.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-database/app/kustomization.yaml
@@ -7,5 +7,8 @@ resources:
   - helmrelease.yaml
   - externalsecret-database.yaml
   - pvc-database.yaml
+  - pvc-dumps.yaml
+  - backup-cronjob.yaml
   - replicationsource.yaml
+  - replicationsource-dumps.yaml
   - volsync-externalsecret.yaml

--- a/kubernetes/apps/base/game-servers/cmangos-database/app/pvc-dumps.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-database/app/pvc-dumps.yaml
@@ -1,0 +1,16 @@
+---
+# Holds logical (mysqldump) backups of the irreplaceable game DBs. Separate
+# from the data PVC so VolSync can ship these dumps to Kopia independently of
+# the crash-consistent RBD snapshot of /var/lib/mysql.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cmangos-db-dumps
+  namespace: game-servers
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/base/game-servers/cmangos-database/app/replicationsource-dumps.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-database/app/replicationsource-dumps.yaml
@@ -1,0 +1,31 @@
+---
+# Ships the logical SQL dumps (cmangos-db-dumps PVC) to Kopia. Reuses the same
+# repo secret as the data-PVC ReplicationSource — Kopia handles multiple
+# sources in one repository. Runs at 05:00, after the 03:00 dump CronJob.
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: cmangos-db-dumps
+spec:
+  sourcePVC: cmangos-db-dumps
+  trigger:
+    schedule: "0 5 * * *"
+  kopia:
+    accessModes:
+      - ReadWriteOnce
+    cacheAccessModes:
+      - ReadWriteOnce
+    cacheCapacity: 2Gi
+    cacheStorageClassName: ceph-block
+    compression: zstd-fastest
+    copyMethod: Snapshot
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    repository: cmangos-database-volsync-secret
+    retain:
+      daily: 7
+      weekly: 4
+    storageClassName: ceph-block
+    volumeSnapshotClassName: csi-ceph-blockpool


### PR DESCRIPTION
## What

Adds restorable SQL-dump backups of the **irreplaceable** game DBs, complementing the existing hourly crash-consistent RBD snapshot.

## Why

The live DBs are **mixed-engine** (verified on the running instance):

| DB | InnoDB | MyISAM |
|---|---|---|
| `classiccharacters` | 79 tables, 452 MB | 13 tables, 41 MB |
| `classicrealmd` | 3 tables | 10 tables, ~1 MB |

MyISAM tables aren't safe to restore from a raw volume snapshot taken mid-write — a logical dump is. The RBD snapshot stays as the fast-restore tier; these dumps are the correctness tier.

## Changes (all in the `cmangos-database` app)

- **`pvc-dumps.yaml`** — dedicated 10Gi PVC for the dumps.
- **`backup-cronjob.yaml`** — nightly (03:00) `mariadb-dump` of `classicrealmd` + `classiccharacters`, gzipped + timestamped, keep newest 7 per DB. Runs as a non-root user; uses the **app user** (`SELECT` is enough for `--single-transaction --no-tablespaces`).
- **`replicationsource-dumps.yaml`** — VolSync ships the dumps PVC to **Kopia** at 05:00, reusing the existing repo secret; `retain: daily 7 / weekly 4`.

`classicmangos` (world) is intentionally **not** dumped — reconstructible via `init-db` + the in-repo migration Jobs. `classiclogs` is disposable.

## Consistency note

`--single-transaction` gives a consistent snapshot of the InnoDB bulk (all player rows) with **no write-blocking**; the few small MyISAM tables are best-effort. Upgrade path: a privileged backup user + `--lock-all-tables` once live root is rotated (after the PTR DB split decouples the on-`main` `db-init` from root=password).

## Validation

- **Live privilege test**: ran the exact dump command as the app user against the running DB — `classicrealmd` dumped 425 KB gzipped of real data; `classiccharacters` schema dumped exit 0. So `SELECT` suffices.
- `kustomize build` app dir → CronJob + dumps PVC + dumps ReplicationSource render
- Flux `$$`-escaping de-escaped and `bash -n`-checked → valid runtime script
- yamllint + full pre-commit suite → passed

https://claude.ai/code/session_01T37E9UJr2ymcGhQoV8Yq93