### PR TITLE
fix(cmangos): force wow DNS record to DNS-only (cloudflare-proxied=false)

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos/app/network/dnsendpoint.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos/app/network/dnsendpoint.yaml
@@ -5,6 +5,12 @@ metadata:
   name: cmangos-wow
   annotations:
     external-dns.alpha.kubernetes.io/external: "true"
+    # MUST be DNS-only (grey-cloud). The WoW client speaks a raw TCP protocol
+    # on 3724 (auth) / 8085 (world); Cloudflare's proxy only carries HTTP(S),
+    # so a proxied record silently breaks all connections. external-dns runs
+    # with a global --cloudflare-proxied default, so without this override it
+    # re-proxies the record on every sync. (2026-06-25 outage root cause.)
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
 spec:
   endpoints:
     - dnsName: "wow.${CLUSTER_DOMAIN}"


### PR DESCRIPTION
**Live outage fix (2026-06-25).** Players couldn't connect.

**Root cause:** `wow.owncloud.ai` was Cloudflare-**proxied** (orange-cloud). The WoW client uses a raw TCP protocol on **3724** (auth) / **8085** (world); Cloudflare's proxy only forwards HTTP(S) and there's no Spectrum, so connections died at CF's edge. external-dns runs with a global `--cloudflare-proxied` default, so the record gets re-proxied on every sync unless explicitly overridden.

**Fix:** add `external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"` so the record stays DNS-only and resolves to the origin IP.

**Verified healthy (not the cause):** origin IP `115.70.0.200` is current (matches realmd egress), realmlist correct + realm online, realmd/mangosd/DB pods Ready, gateway programmed, both TCPRoutes Accepted/ResolvedRefs, realmd:3724 open in-cluster.

A manual CF API flip to grey didn't hold — external-dns reverted it within ~1 min from the global default, which is why the override must live in git.