### PR TITLE
fix(cmangos): set cloudflare-proxied via providerSpecific (DNSEndpoint)

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos/app/network/dnsendpoint.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos/app/network/dnsendpoint.yaml
@@ -5,15 +5,19 @@ metadata:
   name: cmangos-wow
   annotations:
     external-dns.alpha.kubernetes.io/external: "true"
-    # MUST be DNS-only (grey-cloud). The WoW client speaks a raw TCP protocol
-    # on 3724 (auth) / 8085 (world); Cloudflare's proxy only carries HTTP(S),
-    # so a proxied record silently breaks all connections. external-dns runs
-    # with a global --cloudflare-proxied default, so without this override it
-    # re-proxies the record on every sync. (2026-06-25 outage root cause.)
-    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
 spec:
   endpoints:
     - dnsName: "wow.${CLUSTER_DOMAIN}"
       recordType: A
       targets:
         - "${EXTERNAL_IP}"
+      # MUST be DNS-only (grey-cloud). The WoW client speaks a raw TCP protocol
+      # on 3724 (auth) / 8085 (world); Cloudflare's proxy only carries HTTP(S),
+      # so a proxied record silently breaks all connections. external-dns runs
+      # with a global --cloudflare-proxied default, and for a DNSEndpoint (CRD
+      # source) the override MUST be providerSpecific on the endpoint — the
+      # metadata annotation form is ignored for this source, so external-dns
+      # re-proxied the record every sync. (2026-06-25 outage root cause.)
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"


### PR DESCRIPTION
Follow-up to #4110. For a **DNSEndpoint** (external-dns CRD source), the `cloudflare-proxied` override must be **`providerSpecific`** on the endpoint — the metadata-annotation form (#4110) is only honored for ingress/service sources, so external-dns kept re-proxying `wow.owncloud.ai` from its global `--cloudflare-proxied` default and players still couldn't connect.

Verified live: with only the annotation, external-dns reverted a manual grey-cloud back to proxied within ~1 min on every sync. This moves the override to `spec.endpoints[].providerSpecific`.

Incident 2026-06-25 (continued).