### PR TITLE
feat(cmangos): allow both factions on one account (AllowTwoSide.Accounts=1)

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
@@ -429,6 +429,9 @@ spec:
             Rate.Drop.Item.Epic = 1
             Rate.Drop.Money = 3
             Rate.Reputation.Gain = 3
+            # Mirror live: let one account hold both Horde and Alliance
+            # characters on the realm (default 0/blocked if unset).
+            AllowTwoSide.Accounts = 1
             AllowTwoSide.Interaction.Group = 1
             AllowTwoSide.Interaction.Guild = 1
             AllowTwoSide.Interaction.Chat = 1

--- a/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
@@ -361,6 +361,11 @@ spec:
             Rate.Drop.Item.Epic = 1
             Rate.Drop.Money = 3
             Rate.Reputation.Gain = 3
+            # Let a single account create/hold both Horde and Alliance
+            # characters on the realm. Default is 0 (blocked) and falls back to
+            # that if unset — which is why two-faction accounts were impossible
+            # despite the cross-faction interaction settings below.
+            AllowTwoSide.Accounts = 1
             AllowTwoSide.Interaction.Group = 1
             AllowTwoSide.Interaction.Guild = 1
             AllowTwoSide.Interaction.Chat = 1


### PR DESCRIPTION
## What
Lets a single account create and hold **both Horde and Alliance** characters on the realm.

## Root cause
The config enables cross-faction *interaction* (`AllowTwoSide.Interaction.Group/Guild/Chat/Channel = 1`) but never sets **`AllowTwoSide.Accounts`**, so it falls back to the cmangos `.dist` default of **`0` (blocked)**. Per the config docs: *"Allow accounts to create characters in both teams in any game type."* That account-level gate is independent of the interaction toggles, which is why two-faction accounts were impossible.

## Change
`AllowTwoSide.Accounts = 1` on **live** and **PTR** mangosd config (kept in sync).

- Config-only — no code, no DB migration. It only removes the character-creation block; existing characters are unaffected.

## Applying it
mangosd reads its config at **startup**, and the ConfigMap change doesn't restart the pod on its own. After merge it takes effect on the next mangosd rollout:
```
kubectl rollout restart deploy/cmangos-mangosd -n game-servers
```
The preStop hook gives players a graceful **5-minute in-game restart warning** + save before mangosd exits.

## Validation
`kustomize build` renders `AllowTwoSide.Accounts = 1` for both apps; yamllint clean.