### PR TITLE
feat(cmangos): enable full cross-faction interaction (trade/auction/mail/who/friends)

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
@@ -436,6 +436,12 @@ spec:
             AllowTwoSide.Interaction.Guild = 1
             AllowTwoSide.Interaction.Chat = 1
             AllowTwoSide.Interaction.Channel = 1
+            # Mirror live: full cross-faction interaction (all default 0).
+            AllowTwoSide.Interaction.Trade = 1
+            AllowTwoSide.Interaction.Auction = 1
+            AllowTwoSide.Interaction.Mail = 1
+            AllowTwoSide.WhoList = 1
+            AllowTwoSide.AddFriend = 1
             MailDeliveryDelay = 0
             StartPlayerMoney = 100000
             SkillGain.Crafting = 3

--- a/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
@@ -370,6 +370,13 @@ spec:
             AllowTwoSide.Interaction.Guild = 1
             AllowTwoSide.Interaction.Chat = 1
             AllowTwoSide.Interaction.Channel = 1
+            # Full cross-faction interaction (all default 0/blocked): trade,
+            # shared auction houses, mail, /who visibility, and friends list.
+            AllowTwoSide.Interaction.Trade = 1
+            AllowTwoSide.Interaction.Auction = 1
+            AllowTwoSide.Interaction.Mail = 1
+            AllowTwoSide.WhoList = 1
+            AllowTwoSide.AddFriend = 1
             MailDeliveryDelay = 0
             StartPlayerMoney = 100000
             SkillGain.Crafting = 3


### PR DESCRIPTION
Follow-up to #4113. With both factions now allowed on one account, enable the remaining cross-faction interactions (all default `0`): **Trade**, **Auction** (shared AH), **Mail**, **WhoList** (/who), **AddFriend**. Live + PTR, config-only. Applies on the next mangosd rollout (bundled with #4113's restart).