### PR TITLE
fix(cmangos): correct PlayerSave.Interval key (players rolling back ~15m on crash)

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
@@ -450,7 +450,9 @@ spec:
             SkillGain.Weapon = 3
             Rate.Drop.Item.Quest = 3
             Death.Ghost.RunSpeed.World = 1.5
-            PlayerSaveInterval = 60000
+            # Correct key is PlayerSave.Interval (with dot); the old
+            # PlayerSaveInterval was silently ignored -> 15-min default. 60s.
+            PlayerSave.Interval = 60000
             Rate.Health = 3
             Rate.Mana = 3
       # All side-modules mirror live — same module versions in the same

--- a/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
@@ -385,7 +385,12 @@ spec:
             SkillGain.Weapon = 3
             Rate.Drop.Item.Quest = 3
             Death.Ghost.RunSpeed.World = 1.5
-            PlayerSaveInterval = 60000
+            # Periodic save of all online players — the only crash safety net
+            # (a SIGSEGV skips the preStop saveall). The key is PlayerSave.Interval
+            # WITH the dot; the old PlayerSaveInterval was silently ignored, so the
+            # server used the 15-minute default and players rolled back up to ~15m
+            # on a crash. 60000ms = 60s.
+            PlayerSave.Interval = 60000
             Rate.Health = 3
             Rate.Mana = 3
       aiplayerbot-config:


### PR DESCRIPTION
## Symptom
Players lose up to ~10-15 min of progress when something disconnects.

## Root cause
The periodic-save config key was misspelled: `PlayerSaveInterval` (no dot). The server reads **`PlayerSave.Interval`** (with the dot — confirmed at `World.cpp:501`), so the intended **60s** was silently ignored and it used the compiled default of **15 minutes** (`15 * MINUTE * IN_MILLISECONDS`).

The periodic save is the only crash safety net — a hard crash (SIGSEGV) skips the preStop `saveall`, so players revert to the last periodic save, i.e. up to ~15 min. These mangosd pods SIGSEGV periodically, so it bit real players.

## Fix
`PlayerSave.Interval = 60000` (60s) on **live + PTR** → caps crash-loss to ~1 min.

## Notes
- Config-only; applies on the next mangosd rollout (graceful restart).
- With ~1500 bots, saving every 60s is more frequent than the 15-min default; character saves are async-queued so they shouldn't stall the world tick, but worth watching DB CPU after rollout — raise to 120-300s if it spikes.
- **Bonus finding (separate):** `LogGMTrade` and `LogFilter_GMChat` in the same config are also non-existent keys (silently ignored) — they affect GM audit logging, not saves. Worth a follow-up cleanup.

Validated: `kustomize build` shows `PlayerSave.Interval = 60000` and no stale key; yamllint clean.