### PR TITLE
fix(cmangos): pin random-bot population to kill OnBotLogin crash churn (live)

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
@@ -409,13 +409,18 @@ spec:
             AiPlayerbot.RandomBotLoginAtStartup = 0
             AiPlayerbot.RandomBotAccountPrefix = rndbot
             AiPlayerbot.RandomBotAccountCount = 2000
-            # Bots re-enabled at 1500/2000 on 2026-05-24 after PTR
-            # validated the full fix set (PRs #10/#11/#12) under the
-            # same density for 30+ min with no UAF / crash markers.
-            # RandomBotLoginAtStartup=0 above keeps the boot stampede
-            # from racing detour/grid init; bots ramp via the periodic
-            # random-bot tick over the first ~10 min.
-            AiPlayerbot.MinRandomBots = 1500
+            # Min == Max to PIN the population and kill login churn. With a
+            # range (was 1500-2000), RandomPlayerbotMgr re-rolls a random
+            # target via urand(Min,Max) every 30min-2h and logs bots in/out
+            # to chase it — and every one of those logins is an OnBotLogin
+            # call, the exact path of the validated use-after-free crash
+            # (gdb-confirmed on the 2026-06 cores). Pinning at 2000 keeps the
+            # world fully populated (more so — no dips to 1500) while the
+            # target never changes (urand(2000,2000)=2000), so no add/remove
+            # churn and far fewer OnBotLogin crash windows. Reduces the
+            # dominant crash class; the GuardianAI/pet crashes are activity-
+            # driven and still need the upstream guard patch.
+            AiPlayerbot.MinRandomBots = 2000
             AiPlayerbot.MaxRandomBots = 2000
             AiPlayerbot.RandomBotMinLevel = 1
             AiPlayerbot.RandomBotMaxLevel = 60


### PR DESCRIPTION
## Goal
Fewer crashes **without losing the bots** (the populated world).

## Mechanism
The ~daily SIGSEGV is a gdb-validated use-after-free in `PlayerbotHolder::OnBotLogin`, which runs on **every bot login**. `RandomPlayerbotMgr` re-rolls a random target `urand(MinRandomBots, MaxRandomBots)` every 30 min–2 h and logs bots in/out to hit it. Live's **1500–2000 range** means the target constantly oscillates, so bots are constantly added/removed → constant `OnBotLogin` calls → constant crash windows.

## Change (live only)
`MinRandomBots = MaxRandomBots = 2000`. With Min == Max, `urand(2000,2000) = 2000` always, so the target never changes and the add/remove churn stops. The world stays **fully populated — more so**, pinned at 2000 instead of dipping to 1500.

- Keeps every bot; removes the dominant crash trigger.
- PTR untouched (per request).
- Config-only — applies on the next mangosd rollout (graceful 5-min player warning).

## Honest scope
This targets the `OnBotLogin` crashes (the most frequent, most recent — gdb-confirmed). The `GuardianAI`/pet crashes are activity-driven, not login-driven, so they are unaffected — those still need the upstream guard patch. Expect a meaningful drop in crash frequency, not zero.

Validated: kustomize build renders 2000/2000 on live; PTR still 1500/2000; yamllint clean.
