### PR TITLE
feat(cmangos): make dual-spec free on live

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
@@ -585,7 +585,10 @@ spec:
             # Dualspec (amalgamated into attunement by PR #19 — keys
             # previously lived in dualspec.conf, now read from here).
             Dualspec.Enable = 1
-            Dualspec.Cost = 100000
+            # Free dual-spec. 0 = single-click "Unlock Dual Talent
+            # Specialization" with no gold cost / cost-confirm popup.
+            # (PTR mirrors this — also 0.)
+            Dualspec.Cost = 0
             Hardcore.DisablePVP = 0
             Hardcore.SelfFound = 0
       anticheat-config:


### PR DESCRIPTION
Sets `Dualspec.Cost = 0` on live (was `100000` = 10g). Dual-spec unlock becomes free — single-click, no cost-confirm popup.

PTR mirrors this (already `0`; parity PR #4121 keeps it free instead of bumping to 10g, so both stay in sync at free).

Config-only; applies on the next mangosd rollout.