### PR TITLE
fix(cmangos): bound DBErrors.log in the cores-pruner (live+PTR)

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
@@ -277,6 +277,21 @@ spec:
                     find . -maxdepth 1 -name 'core.*' -size 0 -delete 2>/dev/null
                     # shellcheck disable=SC2012
                     ls -1t core.* 2>/dev/null | tail -n +3 | xargs -r rm -f --
+                    # Bound the non-core logs that also land in this dir: mangosd
+                    # cd's here for core capture, so its relative-path logs
+                    # (DBErrors.log, Char.log, EventAIErrors.log, SD2Errors.log)
+                    # get written here and NOTHING else prunes them — DBErrors.log
+                    # reached 11G on live and filled PTR's PVC (2026-06). Truncate
+                    # in place past CAP: mangosd holds them O_APPEND so it keeps
+                    # writing from offset 0 (no orphaned handle, no restart). Plain
+                    # truncate, not copytruncate, so it can never wedge on a full
+                    # disk the way a cp would.
+                    LOG_CAP_KB=$((1024 * 1024))   # 1 GiB per file
+                    for lf in DBErrors.log Char.log EventAIErrors.log SD2Errors.log; do
+                      [ -f "$lf" ] || continue
+                      sz=$(du -k "$lf" 2>/dev/null | cut -f1)
+                      [ -n "$sz" ] && [ "$sz" -gt "$LOG_CAP_KB" ] && : > "$lf"
+                    done
                   fi
                   sleep 600
                 done

--- a/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
@@ -210,6 +210,21 @@ spec:
                     find . -maxdepth 1 -name 'core.*' -size 0 -delete 2>/dev/null
                     # shellcheck disable=SC2012
                     ls -1t core.* 2>/dev/null | tail -n +3 | xargs -r rm -f --
+                    # Bound the non-core logs that also land in this dir: mangosd
+                    # cd's here for core capture, so its relative-path logs
+                    # (DBErrors.log, Char.log, EventAIErrors.log, SD2Errors.log)
+                    # get written here and NOTHING else prunes them — DBErrors.log
+                    # reached 11G on live and filled PTR's PVC (2026-06). Truncate
+                    # in place past CAP: mangosd holds them O_APPEND so it keeps
+                    # writing from offset 0 (no orphaned handle, no restart). Plain
+                    # truncate, not copytruncate, so it can never wedge on a full
+                    # disk the way a cp would.
+                    LOG_CAP_KB=$((1024 * 1024))   # 1 GiB per file
+                    for lf in DBErrors.log Char.log EventAIErrors.log SD2Errors.log; do
+                      [ -f "$lf" ] || continue
+                      sz=$(du -k "$lf" 2>/dev/null | cut -f1)
+                      [ -n "$sz" ] && [ "$sz" -gt "$LOG_CAP_KB" ] && : > "$lf"
+                    done
                   fi
                   sleep 600
                 done


### PR DESCRIPTION
## Problem
mangosd `cd`s into `/opt/mangos/cores` (for core capture), so its **relative-path** logs — `DBErrors.log`, `Char.log`, `EventAIErrors.log`, `SD2Errors.log` — get written there, and **nothing prunes them** (the cores-pruner only handled `core.*`; the logs-pruner only handles `/opt/mangos/logs`). `DBErrors.log` (playerbot pathfinding spam) hit **11 GB on live** and **filled PTR's PVCs** (the source of the recurring `GameServerPVCNearFull` alerts).

## Fix
Extend the **cores-pruner** sidecar to truncate each of those logs past **1 GiB** every cycle:
- In-place truncate (`: > file`) — **safe** because mangosd holds them `O_APPEND`, so it keeps writing from offset 0 (no orphaned handle, no restart).
- Plain truncate, **not** copytruncate — so it can **never wedge on a full disk** the way a `cp` would (which is exactly how PTR's logs-pruner got stuck at 100%).
- Mirrored to **PTR** per the parity principle.

## Apply note
The cores-pruner is a sidecar, so this changes the pod template → applying it **rolls the mangosd pod** (PTR = free/GM-only; live = 5-min player warning). The immediate disk pressure is already relieved (PTR truncated manually); this is the durable fix so it stops recurring.

Validated: `kustomize build` both apps, yamllint clean, pruner script passes `bash -n`.
