### PR TITLE
fix(observability): actually detect read-only PVC volumes cluster-wide

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos/app/prometheusrule.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos/app/prometheusrule.yaml
@@ -148,24 +148,12 @@ spec:
     - name: game-servers.storage
       interval: 1m
       rules:
-        - alert: GameServerVolumeReadOnly
-          expr: |
-            node_filesystem_readonly{
-              mountpoint=~"/var/lib/kubelet/pods/.*",
-              fstype!~"tmpfs|overlay|nsfs"
-            } == 1
-          for: 1m
-          labels:
-            severity: critical
-            team: game-servers
-          annotations:
-            summary: "A pod volume on {{ $labels.instance }} is mounted read-only"
-            description: |
-              Filesystem `{{ $labels.mountpoint }}` on `{{ $labels.instance }}` is read-only.
-              Usually triggered by `errors=remount-ro` after underlying I/O errors (Ceph RBD
-              session loss, disk failure). Pods using this volume will be unable to write —
-              **force-recreate the pod** to remap the volume after underlying storage recovers.
-
+        # NB: read-only-volume detection moved to a cluster-wide KubeVolumeReadOnly
+        # alert in the kube-prometheus-stack PrometheusRule. The old rule here
+        # queried node_filesystem_readonly{mountpoint=~/var/lib/kubelet/pods/.*}
+        # which node-exporter never scraped (all of var/lib/kubelet was excluded),
+        # so it could never fire — and its scope was cluster-wide anyway despite
+        # the team=game-servers label. See fix/detect-readonly-volumes.
         - alert: GameServerPVCNearFull
           expr: |
             (

--- a/kubernetes/apps/base/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -217,6 +217,20 @@ spec:
                   severity: info
     prometheus-node-exporter:
       fullnameOverride: node-exporter
+      # Override the chart's default filesystem mount-points-exclude so CSI PVC
+      # mounts under /var/lib/kubelet/pods/ ARE scraped. The upstream default
+      # excludes ALL of /var/lib/kubelet, which left node_filesystem_readonly
+      # with zero series for PVC mounts — so read-only RBD remounts were
+      # invisible and apps (sonarr/grafana/prowlarr) sat silently broken for
+      # days (2026-06/07) with no alert able to fire. We still exclude
+      # /var/lib/kubelet/plugins (the CSI globalmount just duplicates the
+      # per-pod bind-mount) plus the usual pseudo-filesystems. This admits some
+      # extra pod bind-mount series (etc-hosts etc.) — a modest, bounded
+      # cardinality cost that buys read-only visibility. Args copied verbatim
+      # from the chart default, changing only var/lib/kubelet/.+ -> plugins/.+.
+      extraArgs:
+        - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/containerd/.+|var/lib/docker/.+|var/lib/kubelet/plugins/.+)($|/)
+        - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs|erofs)$
     kube-state-metrics:
       fullnameOverride: kube-state-metrics
       verticalPodAutoscaler:

--- a/kubernetes/apps/base/observability/kube-prometheus-stack/app/prometheusrule.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/app/prometheusrule.yaml
@@ -56,3 +56,32 @@ spec:
             summary: Filesystem has less than 1% space left.
             description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available space left.
             runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodefilesystemalmostoutofspace
+    # Detects PVC volumes remounted read-only (errors=remount-ro after I/O
+    # errors — Ceph RBD session loss etc.). REQUIRES the node-exporter
+    # mount-points-exclude override (see the HelmRelease) that scrapes
+    # /var/lib/kubelet/pods/ — without it node_filesystem_readonly has no series
+    # for PVC mounts and this can never fire. Extracts the pod-UID from the
+    # mountpoint and joins kube_pod_info to name the affected pod. Replaces the
+    # dead, mislabelled game-servers GameServerVolumeReadOnly rule that queried
+    # the same (empty) metric. This is what makes read-only remounts page in
+    # minutes instead of surfacing days later as "my app broke".
+    - name: node-exporter-storage.rules
+      rules:
+        - alert: KubeVolumeReadOnly
+          expr: |-
+            label_replace(
+              node_filesystem_readonly{job="node-exporter",mountpoint=~"/var/lib/kubelet/pods/.+",fstype!~"tmpfs|overlay|nsfs"} == 1,
+              "uid", "$1", "mountpoint", "^/var/lib/kubelet/pods/([^/]+)/.*$"
+            ) * on (uid) group_left (namespace, pod) kube_pod_info
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: Read-only volume on pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.instance }})
+            description: |
+              A volume mounted by pod `{{ $labels.namespace }}/{{ $labels.pod }}` (node `{{ $labels.instance }}`)
+              is mounted READ-ONLY — device `{{ $labels.device }}`, mountpoint `{{ $labels.mountpoint }}`.
+              Usually errors=remount-ro after underlying I/O errors (Ceph RBD session loss, disk failure).
+              The app cannot write and may be silently broken while still "Running".
+              Remediation: once the underlying storage is healthy, force-recreate the pod
+              (kubectl delete pod -n {{ $labels.namespace }} {{ $labels.pod }}) to remap the volume read-write.


### PR DESCRIPTION
## Problem
Read-only Ceph RBD remounts have silently broken apps for days at a time (sonarr, grafana, prowlarr, radarr — Jun/Jul 2026). The alert meant to catch this — `GameServerVolumeReadOnly` — **could never fire**: it queries `node_filesystem_readonly{mountpoint=~"/var/lib/kubelet/pods/.*"}`, but node-exporter's default `mount-points-exclude` drops **all** of `/var/lib/kubelet`, so that metric has **zero series**. Verified live: `count(node_filesystem_readonly{mountpoint=~"/var/lib/kubelet/pods/.*"})` = 0.

## Fix
1. **node-exporter** (`kube-prometheus-stack` HelmRelease): override `mount-points-exclude` so `/var/lib/kubelet/pods/` CSI mounts are scraped. Kept `/var/lib/kubelet/plugins` excluded (the CSI globalmount just duplicates the per-pod bind-mount) and all pseudo-filesystems. Args copied verbatim from the chart default, changing only `var/lib/kubelet/.+` → `plugins/.+`.
2. **New cluster-wide `KubeVolumeReadOnly` alert**: extracts the pod-UID from the mountpoint via `label_replace` and joins `kube_pod_info` (confirmed it carries a `uid` label) to name the actual `namespace/pod`. `severity: critical`, `for: 2m`.
3. **Removed** the dead, mislabelled `GameServerVolumeReadOnly` rule (its scope was cluster-wide anyway despite the `team: game-servers` label).

## Validation
- yamllint + `kustomize build` both apps clean.
- The alert PromQL **parses and executes** against live Prometheus (0 results today — correct, since node-exporter isn't scraping those mounts until this deploys).
- Post-merge check: `node_filesystem_readonly{mountpoint=~"/var/lib/kubelet/pods/.*"}` should return series once the node-exporter DaemonSet rolls.

## Tradeoff (honest)
Un-excluding `/var/lib/kubelet/pods/` admits some extra pod bind-mount series (etc-hosts, termination-log). Modest, bounded cardinality — acceptable for the read-only visibility. Can trim with a `metricRelabelings` drop later if needed.

## Not addressed here
The *root cause* — why RBD sessions keep dropping to read-only (Ceph is `HEALTH_OK`, so client/kernel/network-level) — still wants a separate investigation. This PR is about **detection** so it stops being silent.
