### PR TITLE
fix(cmangos): housekeeping copytruncate silently broken by Flux ${} substitution

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr/app/helmrelease.yaml
@@ -281,7 +281,11 @@ spec:
                         sz=$(du -k "$active" 2>/dev/null | cut -f1)
                         if [ -n "$sz" ] && [ "$sz" -gt "$ACTIVE_CAP_KB" ]; then
                           secs=$(date -u +%s 2>/dev/null || echo rot)
-                          cp "$active" "${active}.${secs}" 2>/dev/null && : > "$active"
+                          # NB: destination uses the no-brace var form on purpose. The
+                          # brace form is eaten by Flux post-build substitution (undefined
+                          # vars become empty, collapsing the path to a bare dot -> cp
+                          # fails same-file), which silently broke this copytruncate.
+                          cp "$active" "$active.$secs" 2>/dev/null && : > "$active"
                         fi
                       fi
                       find . -maxdepth 1 -name '*.log' -size 0 -mmin +5 -delete 2>/dev/null

--- a/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
@@ -216,7 +216,11 @@ spec:
                         sz=$(du -k "$active" 2>/dev/null | cut -f1)
                         if [ -n "$sz" ] && [ "$sz" -gt "$ACTIVE_CAP_KB" ]; then
                           secs=$(date -u +%s 2>/dev/null || echo rot)
-                          cp "$active" "${active}.${secs}" 2>/dev/null && : > "$active"
+                          # NB: destination uses the no-brace var form on purpose. The
+                          # brace form is eaten by Flux post-build substitution (undefined
+                          # vars become empty, collapsing the path to a bare dot -> cp
+                          # fails same-file), which silently broke this copytruncate.
+                          cp "$active" "$active.$secs" 2>/dev/null && : > "$active"
                         fi
                       fi
                       find . -maxdepth 1 -name '*.log' -size 0 -mmin +5 -delete 2>/dev/null


### PR DESCRIPTION
The Server-log copytruncate used `cp "$active" "${active}.${secs}"`, but Flux post-build substitution replaces undefined `${active}`/`${secs}` with empty → destination collapses to `"."` → `cp` fails (same file) → the active log **never truncates**. On live (LogLevel=1) it grew slowly; on **PTR (LogLevel=3 + 2000 bots) it filled the 20Gi logs PVC to 100%** (`GameServerPVCNearFull`). Fixed both to the no-brace `$active.$secs` form. PTR disk already manually relieved (100%→2%).