### PR TITLE
feat(azerothcore): deploy 9c359f85 (real source update + TellMaster crash fix)

### DIFF
--- a/kubernetes/apps/base/game-servers/azerothcore/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/azerothcore/app/helmrelease.yaml
@@ -70,7 +70,7 @@ spec:
           app:
             image:
               repository: ghcr.io/xunholy/azerothcore-wotlk-authserver
-              tag: 7ff4b7aed3513d7f0d89a9c33ccf654189ac64a1
+              tag: 9c359f859a4373c44ec73b69229f1875bef6ba35
             env:
               TZ: ${CLUSTER_TIMEZONE}
               AC_LOGIN_DATABASE_INFO: "azerothcore-database;3306;root;password;acore_auth"
@@ -140,7 +140,7 @@ spec:
           02-db-import:
             image:
               repository: ghcr.io/xunholy/azerothcore-wotlk-db-import
-              tag: 7ff4b7aed3513d7f0d89a9c33ccf654189ac64a1
+              tag: 9c359f859a4373c44ec73b69229f1875bef6ba35
             env:
               AC_LOGIN_DATABASE_INFO: "azerothcore-database;3306;root;password;acore_auth"
               AC_WORLD_DATABASE_INFO: "azerothcore-database;3306;root;password;acore_world"
@@ -155,7 +155,7 @@ spec:
           025-module-sql:
             image:
               repository: ghcr.io/xunholy/azerothcore-wotlk-db-import
-              tag: 7ff4b7aed3513d7f0d89a9c33ccf654189ac64a1
+              tag: 9c359f859a4373c44ec73b69229f1875bef6ba35
             command:
               - /bin/bash
               - -c
@@ -187,17 +187,18 @@ spec:
         containers:
           app:
             image:
-              # 2026-07-06: updated f9bcdac1 (2026-04-30) -> 7ff4b7ae (2026-07-05),
-              # ~2 months of AzerothCore + mod-playerbots updates. Includes the
-              # mod-playerbots "Fix/TellMaster crash" (#2434) addressing the playerbot
-              # use-after-free that was SIGSEGV'ing worldserver (the AC analog of the
-              # cmangos owner-UAF). The db-import init containers (02-db-import +
-              # 025-module-sql, bumped to the same tag) apply pending core + module SQL
-              # migrations BEFORE this boots. Pre-migration backups: VolSync (hourly
-              # Kopia->TrueNAS) + an immediate mysqldump in the DB pod's /tmp. Rollback:
-              # revert all 4 tags to f9bcdac1, restore the dump if migrations misbehaved.
+              # 2026-07-06: 9c359f85 = rebuild from ADVANCED source (resources/Dockerfile):
+              # AC core c62dc737 (Playerbot branch, +501 commits since Apr-24) +
+              # mod-playerbots a119a6de (+114) which lands "Fix/TellMaster crash" (#2434) —
+              # the playerbot use-after-free that was SIGSEGV'ing worldserver (the AC
+              # analog of the cmangos owner-UAF). NB: the prior f9bcdac1 AND 7ff4b7ae tags
+              # were both the SAME Apr-24 source (7ff4b7ae merely rebuilt it), so neither
+              # carried the fix. The db-import init containers (02-db-import + 025-module-sql,
+              # same tag) apply the pending core + module SQL migrations BEFORE this boots.
+              # Pre-migration backups: VolSync (hourly Kopia) + a mysqldump in the DB pod
+              # /tmp. Rollback: revert all 4 tags to 7ff4b7ae, restore the dump if needed.
               repository: ghcr.io/xunholy/azerothcore-wotlk-worldserver
-              tag: 7ff4b7aed3513d7f0d89a9c33ccf654189ac64a1
+              tag: 9c359f859a4373c44ec73b69229f1875bef6ba35
             tty: true
             stdin: true
             # Override the image ENTRYPOINT so we can:


### PR DESCRIPTION
Bumps all 4 AC tags 7ff4b7ae->9c359f85 (rebuild from advanced source: AC core +501, playerbots +114 incl. #2434 TellMaster crash fix). db-import init applies the real DB migrations before boot. Backups: VolSync + fresh mysqldump. Rollback = revert to 7ff4b7ae.