### PR TITLE
feat(observability): detect ext4 emergency_ro read-only (the variant #4127 misses)

### DIFF
--- a/kubernetes/apps/base/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -229,8 +229,59 @@ spec:
       # cardinality cost that buys read-only visibility. Args copied verbatim
       # from the chart default, changing only var/lib/kubelet/.+ -> plugins/.+.
       extraArgs:
+        # Serve the emergency_ro textfile metric written by the sidecar below.
+        - --collector.textfile.directory=/run/textfile
         - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/containerd/.+|var/lib/docker/.+|var/lib/kubelet/plugins/.+)($|/)
         - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs|erofs)$
+      # ext4 `emergency_ro` (fs set read-only after an I/O error) LEAVES the mount
+      # flag as `rw`, so node_filesystem_readonly / KubeVolumeReadOnly (#4127) cannot
+      # see it — that is how qui + 5 apps sat silently read-only for ~7 days (2026-07).
+      # This sidecar scans the host mount table (PID 1 mount ns, readable via hostPID
+      # + the chart's `proc` hostPath) for `emergency_ro` and writes the textfile
+      # metric `node_filesystem_emergency_ro`, which node-exporter serves so
+      # KubeVolumeEmergencyReadOnly can fire. See project_ceph_rbd_readonly_remount.
+      sidecarVolumeMount:
+        # Chart mounts this emptyDir on node-exporter AND every sidecar.
+        - name: emergency-ro-textfile
+          mountPath: /run/textfile
+          readOnly: false
+      sidecars:
+        - name: emergency-ro-collector
+          image: busybox:1.37.0@sha256:026ed7273270ec08f6902b4ae8334c23b473e5394bec3bbbdbfe580c710d50bc
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              while true; do
+                f=/run/textfile/emergency_ro.prom
+                {
+                  echo '# HELP node_filesystem_emergency_ro ext4 filesystem in emergency read-only state after an I/O error (mount flag stays rw). 1 = emergency_ro.'
+                  echo '# TYPE node_filesystem_emergency_ro gauge'
+                  awk '$4 ~ /emergency_ro/ { print "node_filesystem_emergency_ro{device=\"" $1 "\",mountpoint=\"" $2 "\"} 1" }' /host/proc/1/mounts
+                  echo '# HELP node_filesystem_emergency_ro_last_scan_timestamp_seconds Unix time of the last scan (collector liveness).'
+                  echo '# TYPE node_filesystem_emergency_ro_last_scan_timestamp_seconds gauge'
+                  echo "node_filesystem_emergency_ro_last_scan_timestamp_seconds $(date +%s)"
+                } > "$f.tmp" && mv "$f.tmp" "$f"
+                sleep 30
+              done
+          securityContext:
+            runAsUser: 65534
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly: true
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
     kube-state-metrics:
       fullnameOverride: kube-state-metrics
       verticalPodAutoscaler:

--- a/kubernetes/apps/base/observability/kube-prometheus-stack/app/prometheusrule.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/app/prometheusrule.yaml
@@ -85,3 +85,38 @@ spec:
               The app cannot write and may be silently broken while still "Running".
               Remediation: once the underlying storage is healthy, force-recreate the pod
               (kubectl delete pod -n {{ $labels.namespace }} {{ $labels.pod }}) to remap the volume read-write.
+        # ext4 `emergency_ro` sets the fs read-only after an I/O error but LEAVES the
+        # mount flag `rw`, so node_filesystem_readonly (KubeVolumeReadOnly above) is
+        # blind to it — this is the variant that hid qui + 5 apps read-only for ~7
+        # days (2026-07). The node-exporter emergency-ro sidecar (see the HelmRelease)
+        # emits node_filesystem_emergency_ro from the host mount table so this fires.
+        - alert: KubeVolumeEmergencyReadOnly
+          expr: |-
+            label_replace(
+              node_filesystem_emergency_ro{mountpoint=~"/var/lib/kubelet/pods/.+"} == 1,
+              "uid", "$1", "mountpoint", "^/var/lib/kubelet/pods/([^/]+)/.*$"
+            ) * on (uid) group_left (namespace, pod) kube_pod_info
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: Emergency read-only volume on pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.instance }})
+            description: |
+              A volume mounted by pod `{{ $labels.namespace }}/{{ $labels.pod }}` (node `{{ $labels.instance }}`)
+              has entered ext4 `emergency_ro` — device `{{ $labels.device }}`, mountpoint `{{ $labels.mountpoint }}`.
+              The fs went read-only after an I/O error (Ceph RBD watch loss) but the mount flag is still `rw`,
+              so KubeVolumeReadOnly cannot see it. The app is silently failing writes while still "Running".
+              Remediation: scale the workload to 0 then 1 to remap the RBD read-write
+              (a plain pod delete may not clear the cached RO). See project_ceph_rbd_readonly_remount.
+        # Guard the detector itself — the whole point is to never be blind again.
+        - alert: KubeVolumeEmergencyReadOnlyCollectorStale
+          expr: time() - node_filesystem_emergency_ro_last_scan_timestamp_seconds > 300
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: emergency_ro collector stale on {{ $labels.instance }}
+            description: |
+              The node-exporter emergency-ro sidecar on `{{ $labels.instance }}` has not refreshed
+              node_filesystem_emergency_ro for >5m — emergency read-only detection is blind on this node.
+              Check the emergency-ro-collector sidecar in the node-exporter pod.


### PR DESCRIPTION
`node_filesystem_readonly` can't see `emergency_ro` (mount flag stays `rw`) — that's how qui + 5 apps sat silently read-only ~7 days. Adds a node-exporter sidecar that scrapes the host mount table for `emergency_ro` → `node_filesystem_emergency_ro` metric + `KubeVolumeEmergencyReadOnly` alert (pod-joined) + a collector-liveness guard. Non-privileged uid-65534 sidecar reusing the chart's hostPID/proc; verified a 65534 container reads /host/proc/1/mounts.