### PR TITLE
feat(flux): upgrade Flux Operator v0.50 -> v0.53 (Flux 2.8 -> 2.9)

### DIFF
--- a/kubernetes/clusters/cluster-00/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/clusters/cluster-00/flux-system/flux-instance/app/helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
         url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance
         ref:
           # renovate: datasource=docker depName=ghcr.io/controlplaneio-fluxcd/charts/flux-instance
-          tag: 0.50.0
+          tag: 0.53.0
         verify:
           provider: cosign
           matchOIDCIdentity:

--- a/kubernetes/clusters/cluster-00/flux-system/flux-instance/app/values.yaml
+++ b/kubernetes/clusters/cluster-00/flux-system/flux-instance/app/values.yaml
@@ -2,7 +2,7 @@
 ---
 instance:
   distribution:
-    artifact: oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:v0.50.0
+    artifact: oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:v0.53.0
   storage:
     class: "ceph-block"
     size: "10Gi"

--- a/kubernetes/clusters/cluster-00/flux-system/flux-operator/app/helmrelease.yaml
+++ b/kubernetes/clusters/cluster-00/flux-system/flux-operator/app/helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
         url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
         ref:
           # renovate: datasource=docker depName=ghcr.io/controlplaneio-fluxcd/charts/flux-operator
-          tag: 0.50.0
+          tag: 0.53.0
         verify:
           provider: cosign
           matchOIDCIdentity:


### PR DESCRIPTION
Bumps flux-operator + flux-instance charts + the flux-operator-manifests artifact `0.50.0 → 0.53.0`, pulling **Flux 2.9** (Helm v4 SSA, MTTR cuts, CEL health-check improvements) + the operator workload dashboard.

**Why it was stuck:** Renovate detected the grouped update but parked it in **'Pending Status Checks'** on dashboard #3722 — it never opened as a PR, so you drifted 3 minors behind. This gets you current directly.

⚠️ **Control-plane change** — after merge, the flux-operator upgrades itself and rolls the controllers (source/kustomize/helm/notification) to Flux 2.9. Worth watching the reconcile. **Opened for your review.**