### PR TITLE
feat(rook-ceph): CEL health gate on CephCluster HEALTH_ERR

### DIFF
--- a/kubernetes/apps/base/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph/ks.yaml
@@ -26,6 +26,16 @@ metadata:
 spec:
   path: "./apps/base/rook-ceph/rook-ceph/cluster"
   wait: true
+  # CEL health gate (Flux 2.8+). `wait: true` alone only reads the CephCluster's
+  # Ready condition — which Rook keeps True even when Ceph is degraded — so a
+  # genuinely broken cluster stays "healthy" to Flux. This makes Flux fail the
+  # Kustomization on HEALTH_ERR, surfacing a broken Ceph as a reconciliation
+  # failure (and a Flux alert) instead of silence. HEALTH_WARN is tolerated
+  # (transient/expected), so it won't flap; only HEALTH_ERR (genuinely bad) fails.
+  healthCheckExprs:
+    - apiVersion: ceph.rook.io/v1
+      kind: CephCluster
+      current: status.phase == 'Ready' && status.ceph.health != 'HEALTH_ERR'
   targetNamespace: rook-ceph
   dependsOn:
     - name: rook-ceph


### PR DESCRIPTION
`wait: true` only checks the CephCluster's Ready condition (which stays True even when Ceph is degraded). Adds a one-line Flux 2.8+ `healthCheckExprs` CEL gate: `status.phase == 'Ready' && status.ceph.health != 'HEALTH_ERR'` — so a genuinely broken Ceph fails the Kustomization + fires a Flux alert instead of staying silent. `HEALTH_WARN` tolerated (non-flappy). Same pattern as the existing cert-manager ClusterIssuer check. **For review.**