### PR TITLE
feat(kube-system): PodDisruptionBudget for CoreDNS

### DIFF
--- a/kubernetes/apps/base/kube-system/coredns-pdb.yaml
+++ b/kubernetes/apps/base/kube-system/coredns-pdb.yaml
@@ -1,0 +1,15 @@
+---
+# CoreDNS is deployed and managed by Talos (not Flux), so it ships without a
+# PodDisruptionBudget. With only 2 replicas, a rolling node drain / Talos upgrade
+# could evict both at once and take out cluster-wide DNS. minAvailable: 1 lets a
+# drain take one replica at a time while always keeping one CoreDNS serving.
+# Selector matches Talos' CoreDNS Deployment (k8s-app: kube-dns).
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: coredns
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns

--- a/kubernetes/apps/base/kube-system/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/kustomization.yaml
@@ -10,3 +10,4 @@ components:
 resources:
   - namespace.yaml
   - priorityclass.yaml
+  - coredns-pdb.yaml


### PR DESCRIPTION
CoreDNS is Talos-managed with 2 replicas and no PDB — a rolling drain could take out cluster DNS. Adds `minAvailable: 1` (selector `k8s-app: kube-dns`). Wired via the kube-system base kustomization. **For review.**