### PR TITLE
feat(flux): install.remediation on the global HelmRelease patch

### DIFF
--- a/kubernetes/clusters/cluster-00/ks.yaml
+++ b/kubernetes/clusters/cluster-00/ks.yaml
@@ -51,6 +51,11 @@ spec:
                     replace: true
                     crds: CreateReplace
                     createNamespace: true
+                    remediation:
+                      # Retry a failed FIRST install (upgrade.remediation only
+                      # kicks in after a successful install). Without this a
+                      # transient first-install failure leaves the HR stuck.
+                      retries: 3
                   upgrade:
                     remediation:
                       remediateLastFailure: true


### PR DESCRIPTION
The global HR patch retries on *upgrade* failure but not *install* — a transient first-install failure leaves the HR stuck. Adds `install.remediation.retries: 3` cluster-wide (all non-opt-out HRs). One-line resilience win. **For review.**