### PR TITLE
fix(cmangos): promote guardian home-reach null-owner crash fix to live (81d6139f5)

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos/app/helmrelease.yaml
@@ -101,7 +101,18 @@ spec:
               # multi-agent adversarial review returned GO with 0 blockers and 0
               # successful break attempts; ASan build soaked clean on PTR.
               # ROLLBACK: revert tag to 5616d6dff7726035f7fee0d3a70bdd3340db8e86.
-              tag: 6ccbf882074ac7f492e2ee5418535e45304205da
+              #
+              # 2026-07-08: promoted 81d6139f5 = 6ccbf882 + exactly one commit
+              # (branch hotfix/guardian-home-null-owner, workflow_dispatch build).
+              # Fixes a null-owner SIGSEGV in Unit::TriggerHomeEvents: a guardian
+              # whose owner already left the world (logout/despawn) reaches its home
+              # point and dereferences a null owner via owner->IsAlive(). Root-caused
+              # from a live core dump (crash at TriggerHomeEvents+108,
+              # `mov 0x5e0(%rax),%eax` with rax=0 = the pointer returned by the
+              # immediately-preceding GetOwner call). Amplified by bot churn orphaning
+              # guardians. Soaked clean on PTR (0 restarts) before this promotion.
+              # ROLLBACK: revert tag to 6ccbf882074ac7f492e2ee5418535e45304205da.
+              tag: 81d6139f5c1c58f67b22567ce73b9b4f42e6108a
             args: ["mangosd"]
             tty: true
             stdin: true


### PR DESCRIPTION
Promotes **live** from `6ccbf882` to `81d6139f5` = `6ccbf882` + one commit guarding a null owner in `Unit::TriggerHomeEvents`.

Root-caused from a live core dump (`TriggerHomeEvents+108`, `mov 0x5e0(%rax)` with rax=0 = the GetOwner result). A guardian whose owner left the world reaches home and derefs a null owner via `owner->IsAlive()`.

Soaked clean on **PTR** (same image `81d6139f5`, 0 restarts, mangosd Avg Diff 63-79ms) before this promotion. Isolated: one commit on top of the current live image. ROLLBACK: revert tag to `6ccbf882`.