### PR TITLE
fix(cmangos-ptr): escape ${VAR} in migration comment (unblocks kustomization reconcile)

### DIFF
--- a/kubernetes/apps/base/game-servers/cmangos-ptr/app/migrations/ai-playerbot-names-seed-migration-job.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-ptr/app/migrations/ai-playerbot-names-seed-migration-job.yaml
@@ -46,10 +46,13 @@ spec:
             - -c
             - |
               set -euo pipefail
-              # Flux postBuild substitution eats ${VAR} — escape bash
+              # Flux postBuild substitution eats $${VAR} — escape bash
               # parameter expansion as $${VAR} so the runtime container
-              # sees literal ${VAR}. $VAR (no braces) is left alone by
-              # Flux and works as-is.
+              # sees literal $${VAR}. $VAR (no braces) is left alone by
+              # Flux and works as-is. NOTE: escape braces in COMMENTS too —
+              # Flux envsubst runs over the whole manifest text, comments
+              # included, so an unescaped brace reference here fails strict
+              # mode and blocks the entire cmangos-ptr kustomization.
               MARIADB="mariadb -h cmangos-database -P 3306 -u $MANGOS_DBUSER -p$MANGOS_DBPASS"
 
               for tbl in ai_playerbot_names ai_playerbot_guild_names ai_playerbot_arena_team_names; do


### PR DESCRIPTION
**cmangos-ptr kustomization has been failing to reconcile** (Ready=False, BuildFailed) — Flux strict `envsubst` hit a literal `${VAR}` in the names-seed migration job's *comment*. envsubst processes the whole manifest text including comments, so it tried to resolve a var `VAR` (unset) and failed the build, blocking **all** cmangos-ptr changes from applying (including the in-flight crash-fix image bump).

Fix: escape the comment's `${VAR}` -> `$${VAR}` (the prior fix escaped the bash but missed the comment). Live's kustomization was unaffected.