### PR TITLE
fix(volsync): skip recursive chown on mover pods with OnRootMismatch

### DIFF
--- a/kubernetes/apps/base/game-servers/azerothcore/app/replicationsource.yaml
+++ b/kubernetes/apps/base/game-servers/azerothcore/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: azerothcore-database-volsync-secret
     retain:

--- a/kubernetes/apps/base/game-servers/cmangos-database/app/replicationsource.yaml
+++ b/kubernetes/apps/base/game-servers/cmangos-database/app/replicationsource.yaml
@@ -24,6 +24,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: cmangos-database-volsync-secret
     retain:

--- a/kubernetes/apps/base/game-servers/minecraft-bedrock-broadcaster/app/replicationsource.yaml
+++ b/kubernetes/apps/base/game-servers/minecraft-bedrock-broadcaster/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 2000
       fsGroup: 2000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: minecraft-bedrock-broadcaster-volsync-secret
     retain:

--- a/kubernetes/apps/base/game-servers/minecraft-bedrock/app/replicationsource.yaml
+++ b/kubernetes/apps/base/game-servers/minecraft-bedrock/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 2000
       fsGroup: 2000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: minecraft-bedrock-volsync-secret
     retain:

--- a/kubernetes/apps/base/game-servers/minecraft/app/replicationsource.yaml
+++ b/kubernetes/apps/base/game-servers/minecraft/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: minecraft-volsync-secret
     retain:

--- a/kubernetes/apps/base/home-system/autobrr/app/replicationsource.yaml
+++ b/kubernetes/apps/base/home-system/autobrr/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: autobrr-volsync-secret
     retain:

--- a/kubernetes/apps/base/home-system/bazarr/app/replicationsource.yaml
+++ b/kubernetes/apps/base/home-system/bazarr/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: bazarr-volsync-secret
     retain:

--- a/kubernetes/apps/base/home-system/home-assistant/app/replicationsource.yaml
+++ b/kubernetes/apps/base/home-system/home-assistant/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: home-assistant-volsync-secret
     retain:

--- a/kubernetes/apps/base/home-system/jellyseerr/app/replicationsource.yaml
+++ b/kubernetes/apps/base/home-system/jellyseerr/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: jellyseerr-volsync-secret
     retain:

--- a/kubernetes/apps/base/home-system/mosquitto/app/replicationsource.yaml
+++ b/kubernetes/apps/base/home-system/mosquitto/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: mosquitto-volsync-secret
     retain:

--- a/kubernetes/apps/base/home-system/prowlarr/app/replicationsource.yaml
+++ b/kubernetes/apps/base/home-system/prowlarr/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: prowlarr-volsync-secret
     retain:

--- a/kubernetes/apps/base/home-system/qbittorrent/app/replicationsource.yaml
+++ b/kubernetes/apps/base/home-system/qbittorrent/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: qbittorrent-volsync-secret
     retain:

--- a/kubernetes/apps/base/home-system/qui/app/replicationsource.yaml
+++ b/kubernetes/apps/base/home-system/qui/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: qui-volsync-secret
     retain:

--- a/kubernetes/apps/base/home-system/radarr/app/replicationsource.yaml
+++ b/kubernetes/apps/base/home-system/radarr/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: radarr-volsync-secret
     retain:

--- a/kubernetes/apps/base/home-system/recyclarr/app/replicationsource.yaml
+++ b/kubernetes/apps/base/home-system/recyclarr/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: recyclarr-volsync-secret
     retain:

--- a/kubernetes/apps/base/home-system/sabnzbd/app/replicationsource.yaml
+++ b/kubernetes/apps/base/home-system/sabnzbd/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: sabnzbd-volsync-secret
     retain:

--- a/kubernetes/apps/base/home-system/sonarr/app/replicationsource.yaml
+++ b/kubernetes/apps/base/home-system/sonarr/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: sonarr-volsync-secret
     retain:

--- a/kubernetes/apps/base/home-system/tautulli/app/replicationsource.yaml
+++ b/kubernetes/apps/base/home-system/tautulli/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: tautulli-volsync-secret
     retain:

--- a/kubernetes/apps/base/home-system/zigbee2mqtt/app/replicationsource.yaml
+++ b/kubernetes/apps/base/home-system/zigbee2mqtt/app/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: zigbee2mqtt-volsync-secret
     retain:

--- a/kubernetes/apps/base/observability/grafana/instance/replicationsource.yaml
+++ b/kubernetes/apps/base/observability/grafana/instance/replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 1000
       fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: grafana-volsync-secret
     retain:

--- a/kubernetes/apps/base/observability/kube-prometheus-stack/app/alertmanager-replicationsource.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/app/alertmanager-replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 2000
       fsGroup: 2000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: alertmanager-volsync-secret
     retain:

--- a/kubernetes/apps/base/observability/kube-prometheus-stack/app/prometheus-replicationsource.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/app/prometheus-replicationsource.yaml
@@ -20,6 +20,7 @@ spec:
       runAsUser: 1000
       runAsGroup: 2000
       fsGroup: 2000
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: prometheus-volsync-secret
     retain:

--- a/kubernetes/components/volsync/replicationdestination.yaml
+++ b/kubernetes/components/volsync/replicationdestination.yaml
@@ -25,6 +25,7 @@ spec:
       runAsUser: ${VOLSYNC_PUID:=1000}
       runAsGroup: ${VOLSYNC_PGID:=1000}
       fsGroup: ${VOLSYNC_PGID:=1000}
+      fsGroupChangePolicy: OnRootMismatch
     repository: ${APP}-volsync-secret
     sourceIdentity:
       sourceName: ${APP}

--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -21,6 +21,7 @@ spec:
       runAsUser: ${VOLSYNC_PUID:=1000}
       runAsGroup: ${VOLSYNC_PGID:=1000}
       fsGroup: ${VOLSYNC_PGID:=1000}
+      fsGroupChangePolicy: OnRootMismatch
     parallelism: 2
     repository: ${APP}-volsync-secret
     retain:


### PR DESCRIPTION
Every hourly kopia sync triggered a full recursive fsGroup chown of the snapshot mount (150k-300k files per app), delaying backups by minutes and spamming `VolumePermissionChangeInProgress` warnings on every cycle.

Snapshots already carry correct 1000:1000 ownership from the source PVC, so `fsGroupChangePolicy: OnRootMismatch` skips the walk when the mount root already matches. Applied to the shared volsync component (source + destination) and all standalone per-app ReplicationSources — 24 files, one line each.

Verify after merge: next hourly sync's `volsync-src-*` pods should start their mover container in seconds instead of minutes, with no `VolumePermissionChangeInProgress` events.

https://claude.ai/code/session_01VdWKXTWLg4BoreqwJ9UwhM