### PR TITLE
fix(qbittorrent): raise probe timeout from 1s to 5s

### DIFF
--- a/kubernetes/apps/base/home-system/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/base/home-system/qbittorrent/app/helmrelease.yaml
@@ -32,7 +32,9 @@ spec:
                     port: *port
                   initialDelaySeconds: 0
                   periodSeconds: 10
-                  timeoutSeconds: 1
+                  # 1s timed out routinely under heavy seeding I/O, turning
+                  # load into liveness kills mid-transfer.
+                  timeoutSeconds: 5
                   failureThreshold: 3
               readiness: *probes
               startup:


### PR DESCRIPTION
The 1s `timeoutSeconds` on the shared liveness/readiness probe anchor routinely expired while qbittorrent was busy with seeding I/O (readiness timeouts were observed in cluster events), so load turned into probe failures and — at 3 consecutive liveness misses — a pod kill mid-transfer.

5s keeps failure detection fast while tolerating a busy API.

https://claude.ai/code/session_01VdWKXTWLg4BoreqwJ9UwhM