### PR TITLE
fix(home-assistant): complete the code-server OIDC login flow

### DIFF
--- a/kubernetes/apps/base/home-system/home-assistant/app/httproute.yaml
+++ b/kubernetes/apps/base/home-system/home-assistant/app/httproute.yaml
@@ -44,3 +44,35 @@ spec:
         - name: home-assistant
           port: 12321
           weight: 100
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# Separate route (NOT covered by the home-assistant-code SecurityPolicy) so
+# the OIDC callback and sign-in paths reach oauth2-proxy instead of being
+# intercepted by ext-auth — without this the login flow can never complete.
+# Longest-path-prefix precedence sends /oauth2/* here, everything else to the
+# guarded code-server route above.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: home-assistant-code-oauth
+  namespace: home-system
+spec:
+  parentRefs:
+    - name: envoy-external
+      namespace: network-system
+      sectionName: https
+    - name: envoy-internal
+      namespace: network-system
+      sectionName: https
+  hostnames:
+    - 'hass-code.${CLUSTER_DOMAIN}'
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /oauth2/
+      backendRefs:
+        - name: oauth2-proxy
+          namespace: network-system
+          port: 80
+          weight: 100

--- a/kubernetes/apps/base/network-system/dex/app/values.yaml
+++ b/kubernetes/apps/base/network-system/dex/app/values.yaml
@@ -52,6 +52,7 @@ config:
       redirectURIs:
         - 'https://alert-manager.${CLUSTER_DOMAIN}/oauth2/callback'
         - 'https://hass.${CLUSTER_DOMAIN}/oauth2/callback'
+        - 'https://hass-code.${CLUSTER_DOMAIN}/oauth2/callback'
         - 'https://kiali.${CLUSTER_DOMAIN}/oauth2/callback'
         - 'https://prometheus.${CLUSTER_DOMAIN}/oauth2/callback'
         - 'https://sealed-secrets.${CLUSTER_DOMAIN}/oauth2/callback'

--- a/kubernetes/apps/base/network-system/oauth2-proxy/app/referencegrant.yaml
+++ b/kubernetes/apps/base/network-system/oauth2-proxy/app/referencegrant.yaml
@@ -1,7 +1,8 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/referencegrant_v1beta1.json
-# Allows SecurityPolicies in home-system (home-assistant-code ext-auth) to
-# reference the oauth2-proxy Service as their auth backend.
+# Allows SecurityPolicies in home-system (home-assistant-code ext-auth) and
+# HTTPRoutes in home-system (the /oauth2/* callback route) to reference the
+# oauth2-proxy Service as their backend.
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
@@ -10,6 +11,9 @@ spec:
   from:
     - group: gateway.envoyproxy.io
       kind: SecurityPolicy
+      namespace: home-system
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
       namespace: home-system
   to:
     - group: ''


### PR DESCRIPTION
Follow-up to #4172. The gate blocks anonymous access as intended, but end-to-end testing showed the login flow it initiates could not complete: dex rejected `https://hass-code.${CLUSTER_DOMAIN}/oauth2/callback` as an unregistered redirect URI, and the callback path on the guarded route was itself intercepted by ext-auth (redirect loop by design).

- Register the hass-code callback on the dex `oauth2-proxy` static client.
- Add `home-assistant-code-oauth` HTTPRoute: `/oauth2/*` on the same hostname → oauth2-proxy. SecurityPolicy attachment is per-route, so this route is deliberately un-gated; Gateway API longest-prefix precedence keeps everything else on the guarded route.
- Extend the ReferenceGrant to allow HTTPRoute backends from home-system.

After this, anonymous → 302 → dex GitHub SSO → callback sets the `.${CLUSTER_DOMAIN}` cookie → code-server.

https://claude.ai/code/session_01VdWKXTWLg4BoreqwJ9UwhM