### PR TITLE
feat(n8n): Meta social-publishing secret + IG/FB publisher workflow

### DIFF
--- a/kubernetes/apps/base/ai-system/n8n/app/kustomization.yaml
+++ b/kubernetes/apps/base/ai-system/n8n/app/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - httproute.yaml
   - replicationsource.yaml
   - volsync-externalsecret.yaml
+  - meta-externalsecret.yaml
 
 configMapGenerator:
   - name: n8n-values

--- a/kubernetes/apps/base/ai-system/n8n/app/meta-externalsecret.yaml
+++ b/kubernetes/apps/base/ai-system/n8n/app/meta-externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: bedrock-broadcaster-meta
+  namespace: ai-system
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: bedrock-broadcaster-meta
+    template:
+      data:
+        META_APP_ID: "{{ .META_APP_ID }}"
+        META_APP_SECRET: "{{ .META_APP_SECRET }}"
+        META_PAGE_TOKEN: "{{ .META_PAGE_TOKEN }}"
+        IG_ACCOUNT_ID: "{{ .IG_ACCOUNT_ID }}"
+        FB_PAGE_ID: "{{ .FB_PAGE_ID }}"
+  dataFrom:
+    - extract:
+        key: bedrock-broadcaster-meta

--- a/kubernetes/apps/base/ai-system/n8n/app/values.yaml
+++ b/kubernetes/apps/base/ai-system/n8n/app/values.yaml
@@ -10,6 +10,13 @@ main:
   # (used by the token-refresh workflow; n8n blocks ~/.n8n access by default)
   extraEnvVars:
     N8N_BLOCK_FILE_ACCESS_TO_N8N_FILES: "false"
+  # Meta (Instagram + Facebook) publishing credentials, synced from 1Password via
+  # the bedrock-broadcaster-meta ExternalSecret. Exposes META_APP_ID/META_APP_SECRET/
+  # META_PAGE_TOKEN/IG_ACCOUNT_ID/FB_PAGE_ID as env for the social-publisher workflow
+  # (referenced as {{ $env.* }}). NOTE: create the 1Password item BEFORE merging so the
+  # secret exists — envFrom on a missing secret blocks the pod from starting.
+  extraSecretNamesForEnvFrom:
+    - bedrock-broadcaster-meta
   persistence:
     enabled: true
     storageClass: ceph-block

--- a/kubernetes/apps/base/ai-system/n8n/workflows/bedrock-broadcaster-social-publisher.json
+++ b/kubernetes/apps/base/ai-system/n8n/workflows/bedrock-broadcaster-social-publisher.json
@@ -1,0 +1,136 @@
+{
+  "name": "Bedrock Broadcaster — Social Publisher (IG + FB)",
+  "meta": {
+    "description": "Publishes one image + caption to Instagram (2-step container→publish) and the Facebook Page. Credentials come from env (synced by the bedrock-broadcaster-meta ExternalSecret): META_PAGE_TOKEN, IG_ACCOUNT_ID, FB_PAGE_ID. Replace the 'Post Input' Set node with a content-DB lookup (NocoDB/Baserow/Sheets) to drive it from your reusable library. Image URL MUST be publicly reachable (host on your site/Cloudflare/R2) — Meta fetches it server-side."
+  },
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "b1a10000-0000-4000-8000-000000000001",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [-360, 200]
+    },
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            { "field": "hours", "hoursInterval": 12 }
+          ]
+        }
+      },
+      "id": "b1a10000-0000-4000-8000-000000000002",
+      "name": "Schedule (every 12h)",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [-360, 380]
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "a1",
+              "name": "image_url",
+              "value": "https://REPLACE-WITH-PUBLIC-HOST/assets/launch_post_1080.png",
+              "type": "string"
+            },
+            {
+              "id": "a2",
+              "name": "caption",
+              "value": "Play Bedrock on your console the easy way. 🎮\\n\\nConnect PS4 / PS5 / Xbox / Switch / Windows to any Bedrock server — free resource packs, no in-game sign-in headaches.\\n\\n#minecraft #minecraftbedrock #bedrockserver #minecraftconsole #ps4minecraft #xbox #nintendoswitch #bedrockbroadcaster",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "b1a10000-0000-4000-8000-000000000003",
+      "name": "Post Input",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [-120, 290]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://graph.facebook.com/v23.0/{{ $env.IG_ACCOUNT_ID }}/media",
+        "sendBody": true,
+        "contentType": "form-urlencoded",
+        "bodyParameters": {
+          "parameters": [
+            { "name": "image_url", "value": "={{ $json.image_url }}" },
+            { "name": "caption", "value": "={{ $json.caption }}" },
+            { "name": "access_token", "value": "={{ $env.META_PAGE_TOKEN }}" }
+          ]
+        },
+        "options": {}
+      },
+      "id": "b1a10000-0000-4000-8000-000000000004",
+      "name": "IG · Create Container",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [140, 180]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://graph.facebook.com/v23.0/{{ $env.IG_ACCOUNT_ID }}/media_publish",
+        "sendBody": true,
+        "contentType": "form-urlencoded",
+        "bodyParameters": {
+          "parameters": [
+            { "name": "creation_id", "value": "={{ $json.id }}" },
+            { "name": "access_token", "value": "={{ $env.META_PAGE_TOKEN }}" }
+          ]
+        },
+        "options": {}
+      },
+      "id": "b1a10000-0000-4000-8000-000000000005",
+      "name": "IG · Publish",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [380, 180]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://graph.facebook.com/v23.0/{{ $env.FB_PAGE_ID }}/photos",
+        "sendBody": true,
+        "contentType": "form-urlencoded",
+        "bodyParameters": {
+          "parameters": [
+            { "name": "url", "value": "={{ $('Post Input').item.json.image_url }}" },
+            { "name": "caption", "value": "={{ $('Post Input').item.json.caption }}" },
+            { "name": "access_token", "value": "={{ $env.META_PAGE_TOKEN }}" }
+          ]
+        },
+        "options": {}
+      },
+      "id": "b1a10000-0000-4000-8000-000000000006",
+      "name": "FB · Post Photo",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [140, 400]
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [[{ "node": "Post Input", "type": "main", "index": 0 }]]
+    },
+    "Schedule (every 12h)": {
+      "main": [[{ "node": "Post Input", "type": "main", "index": 0 }]]
+    },
+    "Post Input": {
+      "main": [[
+        { "node": "IG · Create Container", "type": "main", "index": 0 },
+        { "node": "FB · Post Photo", "type": "main", "index": 0 }
+      ]]
+    },
+    "IG · Create Container": {
+      "main": [[{ "node": "IG · Publish", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": { "executionOrder": "v1" }
+}


### PR DESCRIPTION
Wires up the Bedrock Broadcaster **Instagram + Facebook** publishing pipeline in n8n, following the repo's existing ESO→`onepassword` conventions.

## Changes (`kubernetes/apps/base/ai-system/n8n/`)
- **`app/meta-externalsecret.yaml`** — ExternalSecret (`onepassword` ClusterSecretStore) syncing a 1Password item → k8s Secret `bedrock-broadcaster-meta` with `META_APP_ID / META_APP_SECRET / META_PAGE_TOKEN / IG_ACCOUNT_ID / FB_PAGE_ID`.
- **`app/kustomization.yaml`** — adds the new ExternalSecret to `resources`.
- **`app/values.yaml`** — `main.extraSecretNamesForEnvFrom: [bedrock-broadcaster-meta]` so n8n gets the creds as env (`{{ $env.* }}`).
- **`workflows/bedrock-broadcaster-social-publisher.json`** — importable n8n workflow: IG 2-step (create container → publish) + FB Page photo. Not Flux-applied (outside the app kustomize path); import via n8n UI.

## 1Password item to create (title: `bedrock-broadcaster-meta`, in your ESO vault)
| Field | Value |
|---|---|
| `META_APP_ID` | `1334895248631750` |
| `META_APP_SECRET` | *(existing)* |
| `FB_PAGE_ID` | `1235125723021984` |
| `META_PAGE_TOKEN` | Bedrock Broadcaster page token |
| `IG_ACCOUNT_ID` | *(empty until IG↔Page link — see below)* |

## ⚠️ Merge ordering
1. **Create the 1Password item first** — `envFrom` on a missing secret blocks the n8n pod from starting.
2. **Facebook posting works immediately.** **Instagram** needs the Bedrock Broadcaster IG account **linked to the Bedrock Broadcaster FB Page** in Meta Business Suite (currently unlinked — the only `instagram_business_account` on the token belongs to a different page, *Reefinity*). Once linked, fill `IG_ACCOUNT_ID` and IG lights up.

Validated locally: `kubectl kustomize` builds clean and picks up the ExternalSecret; workflow JSON parses.