### PR TITLE
feat(n8n): sync R2 credentials for the social pipeline

### DIFF
--- a/kubernetes/apps/base/ai-system/n8n/app/meta-externalsecret.yaml
+++ b/kubernetes/apps/base/ai-system/n8n/app/meta-externalsecret.yaml
@@ -18,6 +18,11 @@ spec:
         META_PAGE_TOKEN: "{{ .META_PAGE_TOKEN }}"
         IG_ACCOUNT_ID: "{{ .IG_ACCOUNT_ID }}"
         FB_PAGE_ID: "{{ .FB_PAGE_ID }}"
+        R2_ACCESS_KEY_ID: "{{ .R2_ACCESS_KEY_ID }}"
+        R2_SECRET_ACCESS_KEY: "{{ .R2_SECRET_ACCESS_KEY }}"
+        R2_ACCOUNT_ID: "{{ .R2_ACCOUNT_ID }}"
+        R2_BUCKET: "{{ .R2_BUCKET }}"
+        R2_PUBLIC_BASE_URL: "{{ .R2_PUBLIC_BASE_URL }}"
   dataFrom:
     - extract:
         key: bedrock-broadcaster-meta


### PR DESCRIPTION
Adds the 5 R2 fields to the `bedrock-broadcaster-meta` ExternalSecret so the Social Content Pipeline's R2 upload node gets S3 creds + a public base URL, synced from 1Password. No new secrets in git.