### PR TITLE
feat(kguardian): serve the assistant from OpenRouter

### DIFF
--- a/kubernetes/apps/base/kguardian/kguardian/app/kustomization.yaml
+++ b/kubernetes/apps/base/kguardian/kguardian/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - secret.enc.age.yaml
   - helmrelease.yaml
   - httproute.yaml
   - httproute-oauth.yaml

--- a/kubernetes/apps/base/kguardian/kguardian/app/secret.enc.age.yaml
+++ b/kubernetes/apps/base/kguardian/kguardian/app/secret.enc.age.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kguardian-openrouter
+  namespace: kguardian
+type: Opaque
+stringData:
+  api-key: ENC[AES256_GCM,data:VfPIhu9/S1IUWj6b6SbuUQNAd9cRrfIZMFxZPexrBIH8UFhBRXhgqkTV/3U0orTPzvxgsTjWHjOWGMi6goxF5Z3PBRiTy3EjnA==,iv:cCLdf0eMXtCXn45fb2boGYHv2vPIL2H1t4Tdsh71Zco=,tag:TpFaaaceMDLJZXSUTzVyYQ==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjOG9wKzZSWEtKd0JkODFv
+        M1JUeGJVZDZJV1RyWTVQWnpORExFVlM0WXhFCi91RjdPQXZBY3lqRXRFYzFremZp
+        NEU0bFdJTWw3c0dDSnFMODRFVUptRUUKLS0tIG1QcTF6cE9qZHZUYTBqRzBYZkFD
+        cXRCRVRTRnoyZGc3T3BqdGlMdDRJeEUKRbNbnVgLnXyN9Zd6rxyLiSO40nIJHnhR
+        FiKL3SRjjfwLKhCNKdLxmX3wEVESTfqQ5OKGtCNxoh+gil+KxMoUqA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age19gj66fq5v2veu940ftyj4pkw0w5tgxgddlyqnd00pnjzyndevurqx70g4t
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-09-04T03:59:54Z"
+  mac: ENC[AES256_GCM,data:6uNbuQwQsgbvadoHrtYjazz4puDiuu4ecNA+WoMr6o7PlDrS2l8j1xTvzeJd5UsRlwpB1IzRtHCkqI040JLpRn+YBwoHWpE92GDE0udkpQHZYEnQp2sg+fGU7I/P2C2GsRkxdpaQNWGNa3qJIXN2Ploai0AF+Q7NGdGl0xhtWK8=,iv:CRL1ufZ1nLxzs074vqTESG9RGu02RLsESQkXhJywTxE=,tag:DZyvx2jIvWyJCSrJ02JUig==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.3

--- a/kubernetes/apps/base/kguardian/kguardian/app/values.yaml
+++ b/kubernetes/apps/base/kguardian/kguardian/app/values.yaml
@@ -57,6 +57,34 @@ seccomp:
 syscalls:
   captureLevel: full
 
+# OpenRouter via the OpenAI-compatible path (chart 1.18.0+ / llm-bridge 1.7.0+).
+# ai.provider selects which env vars the chart writes; "openai" is correct here
+# because OpenRouter speaks the OpenAI /chat/completions wire protocol, not
+# because the model is OpenAI's.
+#
+# The /v1 is REQUIRED. kguardian appends the request path to this base
+# verbatim and never inserts or strips a version segment, so
+# ".../api" would call ".../api/chat/completions" and 404.
+#
+# The model must support tool calling: the assistant always sends its 12 tools,
+# so a model without tool support answers uselessly or errors. Verified against
+# OpenRouter's model API that this slug advertises tools.
+#
+# NOTE this changes which provider answers by default. llm-bridge resolves the
+# default as the first available provider and OPENAI is checked before
+# ANTHROPIC (index.ts availableProvidersFromEnv), so with both keys present
+# OpenRouter serves every request the UI makes (the frontend sends no explicit
+# provider). Anthropic below stays wired as a fallback that only answers when a
+# caller names it. To go back to Anthropic-by-default, comment this block out.
+ai:
+  provider: openai
+  secret: kguardian-openrouter
+  baseUrl: https://openrouter.ai/api/v1
+  # Cheapest current Sonnet on OpenRouter with tool support
+  # ($2/$10 per Mtok vs $3/$15 for 4.5), and keeps the assistant on the same
+  # model family this cluster was already using.
+  model: anthropic/claude-sonnet-5
+
 llmBridge:
   enabled: true
   image:


### PR DESCRIPTION
Adds a SOPS/age-encrypted `kguardian-openrouter` Secret and points the assistant at OpenRouter through the OpenAI-compatible path that landed in chart 1.18.0.

`ai.provider` is `openai` because OpenRouter speaks the OpenAI `/chat/completions` wire protocol, not because the model is OpenAI's. The model is `anthropic/claude-sonnet-5`: it keeps the assistant on the family this cluster already used, and is the cheapest current Sonnet with tool support ($2/$10 per Mtok against $3/$15 for 4.5). Tool support is not optional here, since the assistant always sends its 12 tools and a model without it answers uselessly. Both the slug and its tool capability were checked against OpenRouter's model API rather than assumed.

The `/v1` in the base URL is required. kguardian appends the request path verbatim and never inserts or strips a version segment, so `.../api` would call `.../api/chat/completions` and 404.

**This changes which provider answers by default.** llm-bridge resolves the default as the first available provider and checks `OPENAI` before `ANTHROPIC`, so with both keys present OpenRouter serves every request the UI makes, because the frontend sends no explicit provider. Anthropic stays wired as a fallback that only answers when a caller names it, and commenting out the `ai` block restores the previous behaviour.

Rendered against the published chart 1.21.2: exactly one `OPENAI_API_KEY`, sourced from the new Secret, with the base URL and model set and the Anthropic key still present. The secret is encrypted to the same age recipient as every other secret in this repo, and no plaintext appears anywhere in the tree.

One caveat worth noting: only the native Anthropic path streams token by token. Everything on the OpenAI-compatible path runs to completion and arrives as a single chunk, so the UI will sit quiet and then show the whole answer. Functionally fine, but it feels slower on a long tool-using turn.